### PR TITLE
[TU-49] 전체 회원 명단 개선

### DIFF
--- a/packages/web/src/features/manage-club/members/components/AllMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/AllMemberList.tsx
@@ -3,6 +3,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { hangulIncludes } from "es-hangul";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
@@ -91,14 +92,22 @@ const AllMemberList: React.FC<AllMemberListProps> = ({
   });
 
   const [searchedMembers, setSearchedMembers] = useState(
-    members.members.filter(member => member.name.startsWith(searchText)),
+    members.members.filter(
+      member =>
+        member.name.toLowerCase().includes(searchText.toLowerCase()) ||
+        hangulIncludes(member.name, searchText),
+    ),
   );
 
   const memberCount = searchedMembers.length;
 
   useEffect(() => {
     setSearchedMembers(
-      members.members.filter(member => member.name.startsWith(searchText)),
+      members.members.filter(
+        member =>
+          member.name.toLowerCase().includes(searchText.toLowerCase()) ||
+          hangulIncludes(member.name, searchText),
+      ),
     );
   }, [members.members, searchText]);
 

--- a/packages/web/src/features/manage-club/members/components/MemberSearchAndFilter.tsx
+++ b/packages/web/src/features/manage-club/members/components/MemberSearchAndFilter.tsx
@@ -12,7 +12,10 @@ const SearchAndFilterWrapper = styled.div`
   display: flex;
   flex-direction: row;
   gap: 20px;
-  height: 36px;
+  @media (max-width: ${({ theme }) => theme.responsive.BREAKPOINT.sm}) {
+    flex-direction: column;
+    align-items: flex-end;
+  }
 `;
 
 const ResetButtonWrapper = styled.div`
@@ -41,7 +44,9 @@ const MemberSearchAndFilter: React.FC<
   return (
     <FlexWrapper direction="column" gap={20}>
       <SearchAndFilterWrapper>
-        <SearchInput searchText={searchText} handleChange={handleChange} />
+        <div style={{ width: "100%" }}>
+          <SearchInput searchText={searchText} handleChange={handleChange} />
+        </div>
         <SemesterFilter
           semesters={semesters}
           selectedSemesters={selectedSemesters}


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 멤버 검색 및 필터링 기능 확인 시 문제 없었음 -> es hangul 검색 추가
- search and filter 부분 반응형 레이아웃 (모바일) 수정

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
<img width="652" alt="스크린샷 2025-03-08 오후 3 22 32" src="https://github.com/user-attachments/assets/ec0ff34c-ff3b-491f-9c05-1e9631b7e7d8" />

프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 회원 명단 페이지: http://localhost:3000/manage-club/members
