### PR TITLE
[TU-130] change registration and club name eng length to 100

### DIFF
--- a/packages/api/src/drizzle/schema/club.schema.ts
+++ b/packages/api/src/drizzle/schema/club.schema.ts
@@ -16,7 +16,7 @@ import { Professor, Student } from "./user.schema";
 export const Club = mysqlTable("club", {
   id: int("id").autoincrement().primaryKey(),
   nameKr: varchar("name_kr", { length: 30 }).unique(),
-  nameEn: varchar("name_en", { length: 30 }).unique(),
+  nameEn: varchar("name_en", { length: 100 }).unique(),
   divisionId: int("division_id") // 제일 최신의 분과
     .notNull()
     .references(() => Division.id),

--- a/packages/api/src/drizzle/schema/registration.schema.ts
+++ b/packages/api/src/drizzle/schema/registration.schema.ts
@@ -43,7 +43,7 @@ export const Registration = mysqlTable(
     ).notNull(),
     // .references(() => RegistrationStatusEnum.enumId),
     clubNameKr: varchar("club_name_kr", { length: 30 }),
-    clubNameEn: varchar("club_name_en", { length: 30 }),
+    clubNameEn: varchar("club_name_en", { length: 100 }),
     studentId: int("student_id")
       .notNull()
       .references(() => Student.id),


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

수문연의 등록이 영어 이름 길이로 안되는 이슈 해결
겸사겸사 club도 nameEn 100자로 변경

It closes #issue_number

- 작업요약1
- 작업요약2

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/clubs/1
