### PR TITLE
[TU-137] 테이블 정렬 이슈 및 집행부원 회원등록 통계 데이터 버그 수정

### DIFF
--- a/packages/web/src/common/components/Table.tsx
+++ b/packages/web/src/common/components/Table.tsx
@@ -147,6 +147,7 @@ const Table = <T,>({
                         key={header.id}
                         width={header.column.getSize()}
                         type="HeaderSort"
+                        onClick={header.column.getToggleSortingHandler()}
                       >
                         {flexRender(
                           header.column.columnDef.header,

--- a/packages/web/src/common/components/Table/TableCell.tsx
+++ b/packages/web/src/common/components/Table/TableCell.tsx
@@ -18,6 +18,7 @@ interface TableCellProps {
   children: ReactNode;
   width?: string | number;
   minWidth?: number;
+  onClick?: (event: React.MouseEvent<HTMLTableCellElement>) => void;
 }
 
 const CommonCellHeaderWrapper = styled.th.withConfig({
@@ -89,6 +90,7 @@ const TableCell: React.FC<TableCellProps> = ({
   children,
   width = "150px",
   minWidth = 100,
+  onClick = () => {},
 }) => {
   const isHeader = type === "Header" || type === "HeaderSort";
   const CommonCellWrapper = useMemo(
@@ -124,7 +126,12 @@ const TableCell: React.FC<TableCellProps> = ({
   }
 
   return (
-    <CommonCellWrapper width={width} minWidth={minWidth} isHeader={isHeader}>
+    <CommonCellWrapper
+      width={width}
+      minWidth={minWidth}
+      isHeader={isHeader}
+      onClick={onClick}
+    >
       {content}
     </CommonCellWrapper>
   );

--- a/packages/web/src/features/executive/register-member/components/RegisterInfoTable.tsx
+++ b/packages/web/src/features/executive/register-member/components/RegisterInfoTable.tsx
@@ -64,7 +64,7 @@ const columns = [
   columnHelper.accessor("student.phoneNumber", {
     id: "student.phoneNumber",
     header: "전화번호",
-    cell: info => info.getValue(),
+    cell: info => info.getValue() ?? "-",
     size: 160,
   }),
   columnHelper.accessor("student.email", {

--- a/packages/web/src/features/executive/register-member/frames/ExecutiveRegisterMemberDetailFrame.tsx
+++ b/packages/web/src/features/executive/register-member/frames/ExecutiveRegisterMemberDetailFrame.tsx
@@ -69,7 +69,13 @@ const ExecutiveRegisterMemberDetail: React.FC = () => {
           };
 
         default:
-          return defaultStatusInfo;
+          return {
+            status: RegistrationApplicationStudentStatusEnum.Pending,
+            regular: data.regularMemberRegistrations,
+            nonRegular:
+              data.totalRegistrations - data.regularMemberRegistrations,
+            total: data.totalRegistrations,
+          };
       }
     },
     [data],
@@ -110,7 +116,7 @@ const ExecutiveRegisterMemberDetail: React.FC = () => {
                 )}
               />
               <Divider style={{ marginLeft: 28 }} />
-              <StatusInfoFrame statusInfo={getStatusInfo()} />
+              <StatusInfoFrame statusInfo={getStatusInfo()} isTotal />
             </FlexWrapper>
           </Toggle>
         </Card>

--- a/packages/web/src/features/manage-club/frames/MemberManageFrame.tsx
+++ b/packages/web/src/features/manage-club/frames/MemberManageFrame.tsx
@@ -1,6 +1,7 @@
 import {
   createColumnHelper,
   getCoreRowModel,
+  getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import React from "react";
@@ -27,33 +28,26 @@ const columns = [
     id: "studentNumber",
     header: "학번",
     cell: info => info.getValue(),
-    size: 20,
+    size: 25,
   }),
   columnHelper.accessor("name", {
     id: "name",
     header: "신청자",
     cell: info => info.getValue(),
-    size: 20,
+    size: 25,
   }),
   columnHelper.accessor("phoneNumber", {
     id: "phoneNumber",
     header: "전화번호",
-    cell: info => info.getValue(),
-    size: 20,
+    cell: info => info.getValue() ?? "-",
+    size: 25,
     enableSorting: false,
   }),
   columnHelper.accessor("email", {
     id: "email",
     header: "이메일",
     cell: info => info.getValue(),
-    size: 20,
-    enableSorting: false,
-  }),
-  columnHelper.display({
-    id: "remarks",
-    header: "비고",
-    cell: () => " ",
-    size: 20,
+    size: 25,
     enableSorting: false,
   }),
 ];
@@ -80,6 +74,7 @@ const MemberManageFrame: React.FC = () => {
     columns,
     data: membersData.members,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   });
 
   // 자신이 대표자인 동아리 clubId에 해당하는 동아리 세부정보 가져오기

--- a/packages/web/src/features/manage-club/members/components/AllMemberList.tsx
+++ b/packages/web/src/features/manage-club/members/components/AllMemberList.tsx
@@ -1,6 +1,7 @@
 import {
   createColumnHelper,
   getCoreRowModel,
+  getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import React, { useState } from "react";
@@ -37,33 +38,26 @@ const columns = [
     id: "studentNumber",
     header: "학번",
     cell: info => info.getValue(),
-    size: 20,
+    size: 25,
   }),
   columnHelper.accessor("name", {
     id: "name",
     header: "신청자",
     cell: info => info.getValue(),
-    size: 20,
+    size: 25,
   }),
   columnHelper.accessor("phoneNumber", {
     id: "phoneNumber",
     header: "전화번호",
     cell: info => info.getValue() ?? "-",
-    size: 20,
+    size: 25,
     enableSorting: false,
   }),
   columnHelper.accessor("email", {
     id: "email",
     header: "이메일",
     cell: info => info.getValue(),
-    size: 20,
-    enableSorting: false,
-  }),
-  columnHelper.display({
-    id: "remarks",
-    header: "비고",
-    cell: () => " ",
-    size: 20,
+    size: 25,
     enableSorting: false,
   }),
 ];
@@ -91,6 +85,7 @@ const AllMemberList: React.FC<AllMemberListProps> = ({
     columns,
     data: searchedMembers,
     getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   });
 
   return (


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 테이블 정렬 기능이 관련 호출 메서드가 빠져있어서 추가함
- 대표자관리 쪽 테이블 정렬 기능 동작하도록 수정
- 집행부원 회원 등록 통계 데이터 표시 버그 수정

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/clubs/1
