### PR TITLE
[TU-119] division tag color 중복 사용 버그 해결

### DIFF
--- a/packages/web/src/common/hooks/useGetDivisionType.ts
+++ b/packages/web/src/common/hooks/useGetDivisionType.ts
@@ -1,37 +1,12 @@
+import { getDivisionTagColor } from "@sparcs-clubs/web/constants/tableTagList";
 import { StatusDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
-import { TagColor } from "../components/Tag";
 import useGetDivisions from "../services/getDivisions";
 
 const useGetDivisionType = () => {
   const { data, isLoading, isError } = useGetDivisions();
 
   const divisionTypeList = data?.divisions;
-
-  const getDivisionTagColor = (name: string): TagColor => {
-    switch (name) {
-      case "생활체육":
-      case "구기체육":
-        return "PINK";
-      case "인문학술":
-      case "이공학술":
-        return "YELLOW";
-      case "연행예술":
-      case "전시창작":
-        return "BLUE";
-      case "생활문화":
-      case "식생활":
-      case "대중문화":
-        return "GREEN";
-      case "사회":
-      case "종교":
-        return "PURPLE";
-      case "밴드음악":
-        return "ORANGE";
-      default:
-        return "ORANGE";
-    }
-  };
 
   const divisionTypeTagList: { [key in number]: StatusDetail } =
     divisionTypeList?.reduce(

--- a/packages/web/src/constants/tableTagList.ts
+++ b/packages/web/src/constants/tableTagList.ts
@@ -175,6 +175,31 @@ const ClubTypeTagList: {
   [ClubTypeEnum.Provisional]: { text: "가동아리", color: "ORANGE" },
 };
 
+const getDivisionTagColor = (name: string): TagColor => {
+  switch (name) {
+    case "생활체육":
+    case "구기체육":
+      return "PINK";
+    case "인문학술":
+    case "이공학술":
+      return "YELLOW";
+    case "연행예술":
+    case "전시창작":
+      return "BLUE";
+    case "생활문화":
+    case "식생활":
+    case "대중문화":
+      return "GREEN";
+    case "사회":
+    case "종교":
+      return "PURPLE";
+    case "밴드음악":
+      return "ORANGE";
+    default:
+      return "ORANGE";
+  }
+};
+
 export {
   AcfTagList,
   ActStatusTagList,
@@ -190,4 +215,5 @@ export {
   RegistrationStatusTagList,
   RegistrationTypeTagList,
   RntTagList,
+  getDivisionTagColor,
 };

--- a/packages/web/src/features/activity-report/components/executive/ChargedActivityModalTable.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ChargedActivityModalTable.tsx
@@ -9,8 +9,10 @@ import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
 
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import { ClubTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
-import { getTagColorFromDivision } from "@sparcs-clubs/web/types/clubdetail.types";
+import {
+  ClubTypeTagList,
+  getDivisionTagColor,
+} from "@sparcs-clubs/web/constants/tableTagList";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface ChargedClubsAndProgresses {
@@ -42,9 +44,7 @@ const columns = [
   columnHelper.accessor("divisionName", {
     header: "분과",
     cell: info => (
-      <Tag color={getTagColorFromDivision(info.getValue())}>
-        {info.getValue()}
-      </Tag>
+      <Tag color={getDivisionTagColor(info.getValue())}>{info.getValue()}</Tag>
     ),
     size: 50,
   }),

--- a/packages/web/src/features/activity-report/components/executive/ExecutiveActivityClubTable.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutiveActivityClubTable.tsx
@@ -15,8 +15,10 @@ import Table from "@sparcs-clubs/web/common/components/Table";
 import CheckboxCenterPlacerStopPropagation from "@sparcs-clubs/web/common/components/Table/CheckboxCenterPlacerStopPropagation";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
-import { ClubTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
-import { getTagColorFromDivision } from "@sparcs-clubs/web/types/clubdetail.types";
+import {
+  ClubTypeTagList,
+  getDivisionTagColor,
+} from "@sparcs-clubs/web/constants/tableTagList";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface ExecutiveActivityClubTableProps {
@@ -52,9 +54,7 @@ const columns = [
   columnHelper.accessor("divisionName", {
     header: "분과",
     cell: info => (
-      <Tag color={getTagColorFromDivision(info.getValue())}>
-        {info.getValue()}
-      </Tag>
+      <Tag color={getDivisionTagColor(info.getValue())}>{info.getValue()}</Tag>
     ),
     size: 120,
   }),

--- a/packages/web/src/features/executive/funding/components/ChargedFundingModalTable.tsx
+++ b/packages/web/src/features/executive/funding/components/ChargedFundingModalTable.tsx
@@ -8,8 +8,10 @@ import { ClubTypeEnum } from "@clubs/interface/common/enum/club.enum";
 
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import { ClubTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
-import { getTagColorFromDivision } from "@sparcs-clubs/web/types/clubdetail.types";
+import {
+  ClubTypeTagList,
+  getDivisionTagColor,
+} from "@sparcs-clubs/web/constants/tableTagList";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface ChargedClubAndFundings {
@@ -38,9 +40,7 @@ const columns = [
   columnHelper.accessor("divisionName", {
     header: "분과",
     cell: info => (
-      <Tag color={getTagColorFromDivision(info.getValue())}>
-        {info.getValue()}
-      </Tag>
+      <Tag color={getDivisionTagColor(info.getValue())}>{info.getValue()}</Tag>
     ),
     size: 50,
   }),

--- a/packages/web/src/features/executive/funding/components/ExecutiveFundingClubTable.tsx
+++ b/packages/web/src/features/executive/funding/components/ExecutiveFundingClubTable.tsx
@@ -15,8 +15,10 @@ import Table from "@sparcs-clubs/web/common/components/Table";
 import CheckboxCenterPlacerStopPropagation from "@sparcs-clubs/web/common/components/Table/CheckboxCenterPlacerStopPropagation";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
-import { ClubTypeTagList } from "@sparcs-clubs/web/constants/tableTagList";
-import { getTagColorFromDivision } from "@sparcs-clubs/web/types/clubdetail.types";
+import {
+  ClubTypeTagList,
+  getDivisionTagColor,
+} from "@sparcs-clubs/web/constants/tableTagList";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface ExecutiveFundingClubTableProps {
@@ -52,9 +54,7 @@ const columns = [
   columnHelper.accessor(row => row.division.name, {
     header: "분과",
     cell: info => (
-      <Tag color={getTagColorFromDivision(info.getValue())}>
-        {info.getValue()}
-      </Tag>
+      <Tag color={getDivisionTagColor(info.getValue())}>{info.getValue()}</Tag>
     ),
     size: 120,
   }),

--- a/packages/web/src/features/executive/register-member/components/RegisterMemberTable.tsx
+++ b/packages/web/src/features/executive/register-member/components/RegisterMemberTable.tsx
@@ -9,9 +9,9 @@ import { ApiReg019ResponseOk } from "@clubs/interface/api/registration/endpoint/
 
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
+import { getDivisionTagColor } from "@sparcs-clubs/web/constants/tableTagList";
 import {
   getTagColorFromClubType,
-  getTagColorFromDivision,
   getTagContentFromClubType,
 } from "@sparcs-clubs/web/types/clubdetail.types";
 
@@ -43,7 +43,7 @@ const columns = [
     id: "division.name",
     header: "분과",
     cell: info => {
-      const tagColor = getTagColorFromDivision(`${info.getValue()}`);
+      const tagColor = getDivisionTagColor(`${info.getValue()}`);
 
       return <Tag color={tagColor}>{info.getValue()}</Tag>;
     },

--- a/packages/web/src/features/manage-club/frames/ProfessorManageClubFrame/ClubInfoSection.tsx
+++ b/packages/web/src/features/manage-club/frames/ProfessorManageClubFrame/ClubInfoSection.tsx
@@ -7,10 +7,10 @@ import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import FoldableSectionTitle from "@sparcs-clubs/web/common/components/FoldableSectionTitle";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import Typography from "@sparcs-clubs/web/common/components/Typography";
+import { getDivisionTagColor } from "@sparcs-clubs/web/constants/tableTagList";
 import { useGetClubDetail } from "@sparcs-clubs/web/features/clubs/services/useGetClubDetail";
 import {
   getTagColorFromClubType,
-  getTagColorFromDivision,
   getTagContentFromClubType,
 } from "@sparcs-clubs/web/types/clubdetail.types";
 
@@ -71,7 +71,7 @@ const ClubInfoSection: React.FC<ClubInfoSectionProps> = ({ clubId }) => {
               <ClubInfoItem
                 title="소속 분과"
                 content={
-                  <Tag color={getTagColorFromDivision(data.division.name)}>
+                  <Tag color={getDivisionTagColor(data.division.name)}>
                     {data.division.name}
                   </Tag>
                 }

--- a/packages/web/src/features/my/components/MyClubProfTable.tsx
+++ b/packages/web/src/features/my/components/MyClubProfTable.tsx
@@ -9,8 +9,10 @@ import { ApiReg021ResponseOk } from "@clubs/interface/api/registration/endpoint/
 
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import { RegistrationStatusTagList } from "@sparcs-clubs/web/constants/tableTagList";
-import { getTagColorFromDivision } from "@sparcs-clubs/web/types/clubdetail.types";
+import {
+  getDivisionTagColor,
+  RegistrationStatusTagList,
+} from "@sparcs-clubs/web/constants/tableTagList";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface MyClubTableProps {
@@ -34,9 +36,7 @@ const columns = [
     id: "division.name",
     header: "분과",
     cell: info => (
-      <Tag color={getTagColorFromDivision(info.getValue())}>
-        {info.getValue()}
-      </Tag>
+      <Tag color={getDivisionTagColor(info.getValue())}>{info.getValue()}</Tag>
     ),
     size: 10,
   }),

--- a/packages/web/src/features/my/components/MyClubTable.tsx
+++ b/packages/web/src/features/my/components/MyClubTable.tsx
@@ -10,10 +10,10 @@ import { ApiReg012ResponseOk } from "@clubs/interface/api/registration/endpoint/
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
 import {
+  getDivisionTagColor,
   RegistrationStatusTagList,
   RegistrationTypeTagList,
 } from "@sparcs-clubs/web/constants/tableTagList";
-import { getTagColorFromDivision } from "@sparcs-clubs/web/types/clubdetail.types";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
 
 interface MyClubTableProps {
@@ -50,9 +50,7 @@ const columns = [
     id: "divisionName",
     header: "분과",
     cell: info => (
-      <Tag color={getTagColorFromDivision(info.getValue())}>
-        {info.getValue()}
-      </Tag>
+      <Tag color={getDivisionTagColor(info.getValue())}>{info.getValue()}</Tag>
     ),
     size: 10,
   }),

--- a/packages/web/src/features/my/components/MyMemberTable.tsx
+++ b/packages/web/src/features/my/components/MyMemberTable.tsx
@@ -9,10 +9,12 @@ import { ApiReg006ResponseOk } from "@clubs/interface/api/registration/endpoint/
 
 import Table from "@sparcs-clubs/web/common/components/Table";
 import Tag from "@sparcs-clubs/web/common/components/Tag";
-import { RegistrationStatusTagList } from "@sparcs-clubs/web/constants/tableTagList";
+import {
+  getDivisionTagColor,
+  RegistrationStatusTagList,
+} from "@sparcs-clubs/web/constants/tableTagList";
 import {
   getTagColorFromClubType,
-  getTagColorFromDivision,
   getTagContentFromClubType,
 } from "@sparcs-clubs/web/types/clubdetail.types";
 import { getTagDetail } from "@sparcs-clubs/web/utils/getTagDetail";
@@ -59,9 +61,7 @@ const columns = [
     id: "divisionName",
     header: "분과",
     cell: info => (
-      <Tag color={getTagColorFromDivision(info.getValue())}>
-        {info.getValue()}
-      </Tag>
+      <Tag color={getDivisionTagColor(info.getValue())}>{info.getValue()}</Tag>
     ),
     size: 10,
   }),

--- a/packages/web/src/types/clubdetail.types.ts
+++ b/packages/web/src/types/clubdetail.types.ts
@@ -40,34 +40,4 @@ const getTagContentFromClubType = (
   return content;
 };
 
-const getTagColorFromDivision = (divisionName: string): TagColor => {
-  // TODO : getTagDetail 사용
-  switch (divisionName) {
-    case "생활문화":
-    case "사회":
-      return "GREEN";
-    case "연행예술":
-    case "종교":
-      return "BLUE";
-    case "전시창작":
-    case "구기체육":
-      return "ORANGE";
-    case "밴드음악":
-    case "생활체육":
-      return "PURPLE";
-    case "이공학술":
-    case "보컬음악":
-      return "PINK";
-    case "연주음악":
-    case "인문학술":
-      return "YELLOW";
-    default:
-      return "GREEN"; // 기본값 임의 지정
-  }
-};
-
-export {
-  getTagColorFromClubType,
-  getTagColorFromDivision,
-  getTagContentFromClubType,
-};
+export { getTagColorFromClubType, getTagContentFromClubType };


### PR DESCRIPTION
# 📌 요약 \*
useGetDivisonType의 getDivisionTagColor와 getTagColorFromDivision이 중복 사용되기 때문에 useGetDivisonType의 getDivisionTagColor로 모든 사용을 통일하기 위해서 getTagColorFromDivision를 삭제하고 useGetDivisonType의 getDivisionTagColor를 tableTagList로 옮김 (usage들도 알맞게 수정함)

## ⭐문서 링크⭐
https://www.notion.so/sparcs/25-03-26-Clubs-1c2c25603b0b8072ad68c76411fc7424?p=1b4c25603b0b802eb60bf309605cab69&pm=s


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->

# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 
<img width="1059" alt="스크린샷 2025-03-30 오후 1 40 50" src="https://github.com/user-attachments/assets/b5b731b1-c894-420d-a8e9-271ea3d645e3" />

1. 마이페이지 하단 테이블 (분과 태그 색상 사용된 곳들의 예시 중 하나) : http://localhost:3000/my
