### PR TITLE
[TU-203] `src/**/*` import 차단

### DIFF
--- a/packages/api/src/drizzle/drizzle.config.ts
+++ b/packages/api/src/drizzle/drizzle.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "drizzle-kit";
-import { env } from "src/env";
+
+import { env } from "@sparcs-clubs/api/env";
 
 export default {
   driver: "mysql2",

--- a/packages/api/src/feature/activity-certificate/activity-certificate.module.ts
+++ b/packages/api/src/feature/activity-certificate/activity-certificate.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
 
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 import ClubModule from "@sparcs-clubs/api/feature/club/club.module";
 import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 

--- a/packages/api/src/feature/activity-certificate/repository/activity-certificate.repository.ts
+++ b/packages/api/src/feature/activity-certificate/repository/activity-certificate.repository.ts
@@ -1,15 +1,16 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, count, desc, eq, gte, lte } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
-import {
-  ActivityCertificate,
-  ActivityCertificateItem,
-} from "src/drizzle/schema/activity-certificate.schema";
 
 import type { ApiAcf003RequestQuery } from "@clubs/interface/api/activity-certificate/endpoint/apiAcf003";
 import type { ApiAcf007RequestQuery } from "@clubs/interface/api/activity-certificate/endpoint/apiAcf007";
 import { ActivityCertificateOrderStatusEnum } from "@clubs/interface/common/enum/activityCertificate.enum";
+
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import {
+  ActivityCertificate,
+  ActivityCertificateItem,
+} from "@sparcs-clubs/api/drizzle/schema/activity-certificate.schema";
 
 @Injectable()
 export class ActivityCertificateRepository {

--- a/packages/api/src/feature/activity/activity.module.ts
+++ b/packages/api/src/feature/activity/activity.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import ClubModule from "../club/club.module";
 import ClubTRepository from "../club/repository-old/club.club-t.repository";

--- a/packages/api/src/feature/auth/auth.module.ts
+++ b/packages/api/src/feature/auth/auth.module.ts
@@ -1,7 +1,8 @@
 import { Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import UserModule from "../user/user.module";
 import { AuthController } from "./controller/auth.controller";

--- a/packages/api/src/feature/auth/repository/auth.repository.ts
+++ b/packages/api/src/feature/auth/repository/auth.repository.ts
@@ -1,9 +1,9 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
 import { getKSTDate, takeOne } from "@sparcs-clubs/api/common/util/util";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import { AuthActivatedRefreshTokens } from "@sparcs-clubs/api/drizzle/schema/refresh-token.schema";
 import { SemesterD } from "@sparcs-clubs/api/drizzle/schema/semester.schema";
 import {

--- a/packages/api/src/feature/club/club.module.ts
+++ b/packages/api/src/feature/club/club.module.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import DivisionModule from "../division/division.module";
 import DivisionRepository from "../division/repository/division.repository";

--- a/packages/api/src/feature/club/delegate/club.club-delegate-d.repository.ts
+++ b/packages/api/src/feature/club/delegate/club.club-delegate-d.repository.ts
@@ -13,15 +13,6 @@ import {
   or,
 } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { getKSTDate, takeOne } from "src/common/util/util";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
-import {
-  ClubDelegate,
-  ClubDelegateChangeRequest,
-  ClubOld,
-  ClubStudentT,
-} from "src/drizzle/schema/club.schema";
-import { Student } from "src/drizzle/schema/user.schema";
 
 import {
   ClubDelegateChangeRequestStatusEnum,
@@ -29,6 +20,15 @@ import {
 } from "@clubs/interface/common/enum/club.enum";
 
 import logger from "@sparcs-clubs/api/common/util/logger";
+import { getKSTDate, takeOne } from "@sparcs-clubs/api/common/util/util";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import {
+  ClubDelegate,
+  ClubDelegateChangeRequest,
+  ClubOld,
+  ClubStudentT,
+} from "@sparcs-clubs/api/drizzle/schema/club.schema";
+import { Student } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 
 @Injectable()
 export class ClubDelegateDRepository {

--- a/packages/api/src/feature/club/repository-old/club-old.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club-old.repository.ts
@@ -18,7 +18,6 @@ import {
 } from "drizzle-orm";
 import { union } from "drizzle-orm/mysql-core";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
 import { ISemester } from "@clubs/domain/semester/semester";
 
@@ -30,6 +29,7 @@ import {
 } from "@clubs/interface/common/enum/club.enum";
 
 import { getKSTDate, takeOne } from "@sparcs-clubs/api/common/util/util";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import {
   ClubDelegate,
   ClubOld,

--- a/packages/api/src/feature/club/repository-old/club.club-room-t.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club.club-room-t.repository.ts
@@ -1,9 +1,13 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, desc, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { getKSTDate, takeOne } from "src/common/util/util";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
-import { ClubBuildingEnum, ClubRoomT } from "src/drizzle/schema/club.schema";
+
+import { getKSTDate, takeOne } from "@sparcs-clubs/api/common/util/util";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import {
+  ClubBuildingEnum,
+  ClubRoomT,
+} from "@sparcs-clubs/api/drizzle/schema/club.schema";
 
 @Injectable()
 export class ClubRoomTRepository {

--- a/packages/api/src/feature/club/repository-old/club.club-student-t.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club.club-student-t.repository.ts
@@ -15,15 +15,15 @@ import {
   or,
 } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import {
-  ClubDelegate,
-  ClubOld,
-  ClubStudentT,
-} from "src/drizzle/schema/club.schema";
 
 import logger from "@sparcs-clubs/api/common/util/logger";
 import { takeOne } from "@sparcs-clubs/api/common/util/util";
 import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import {
+  ClubDelegate,
+  ClubOld,
+  ClubStudentT,
+} from "@sparcs-clubs/api/drizzle/schema/club.schema";
 import { SemesterD } from "@sparcs-clubs/api/drizzle/schema/semester.schema";
 import { Student } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 import { MStudent } from "@sparcs-clubs/api/feature/user/model/student.model";

--- a/packages/api/src/feature/club/repository-old/club.club-t.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club.club-t.repository.ts
@@ -1,10 +1,10 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, desc, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
-import { ClubT } from "src/drizzle/schema/club.schema";
 
 import { getKSTDate, takeOne } from "@sparcs-clubs/api/common/util/util";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import { ClubT } from "@sparcs-clubs/api/drizzle/schema/club.schema";
 import { SemesterD } from "@sparcs-clubs/api/drizzle/schema/semester.schema";
 import { Professor } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 

--- a/packages/api/src/feature/club/repository-old/club.division-permanent-club-d.repository.ts
+++ b/packages/api/src/feature/club/repository-old/club.division-permanent-club-d.repository.ts
@@ -1,8 +1,8 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import { DivisionPermanentClubD } from "@sparcs-clubs/api/drizzle/schema/division.schema";
 
 @Injectable()

--- a/packages/api/src/feature/file/file.module.ts
+++ b/packages/api/src/feature/file/file.module.ts
@@ -1,6 +1,7 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { forwardRef, Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import ClubModule from "../club/club.module";
 import { FileController } from "./controller/file.controller";

--- a/packages/api/src/feature/file/repository/file.repository.ts
+++ b/packages/api/src/feature/file/repository/file.repository.ts
@@ -1,8 +1,9 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, eq, inArray } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
-import { File } from "src/drizzle/schema/file.schema";
+
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import { File } from "@sparcs-clubs/api/drizzle/schema/file.schema";
 
 import { MFile } from "../model/file.model";
 

--- a/packages/api/src/feature/funding/funding.module.ts
+++ b/packages/api/src/feature/funding/funding.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import ActivityModule from "../activity/activity.module";
 import ClubModule from "../club/club.module";

--- a/packages/api/src/feature/meeting/entity/content/content.module.ts
+++ b/packages/api/src/feature/meeting/entity/content/content.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
 
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 
 import ContentController from "./content.controller";

--- a/packages/api/src/feature/meeting/entity/content/content.repository.ts
+++ b/packages/api/src/feature/meeting/entity/content/content.repository.ts
@@ -5,11 +5,11 @@ import {
 } from "@nestjs/common";
 import { and, eq, max, sql } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
 import { MeetingAgendaEntityTypeEnum } from "@clubs/interface/common/enum/meeting.enum";
 
 import logger from "@sparcs-clubs/api/common/util/logger";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 // import { getKSTDate } from "@sparcs-clubs/api/common/util/util";
 import {
   MeetingAgendaContent,

--- a/packages/api/src/feature/meeting/entity/entity.module.ts
+++ b/packages/api/src/feature/meeting/entity/entity.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
 
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 
 import { ContentModule } from "./content/content.module";

--- a/packages/api/src/feature/meeting/entity/entity.repository.ts
+++ b/packages/api/src/feature/meeting/entity/entity.repository.ts
@@ -5,11 +5,11 @@ import {
 } from "@nestjs/common";
 import { and, eq, isNull, or } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
 import { MeetingAgendaEntityTypeEnum } from "@clubs/interface/common/enum/meeting.enum";
 
 import logger from "@sparcs-clubs/api/common/util/logger";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 // import { getKSTDate } from "@sparcs-clubs/api/common/util/util";
 import {
   MeetingAgendaContent,

--- a/packages/api/src/feature/meeting/entity/vote/vote.module.ts
+++ b/packages/api/src/feature/meeting/entity/vote/vote.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
 
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 import UserModule from "@sparcs-clubs/api/feature/user/user.module";
 
 import VoteController from "./vote.controller";

--- a/packages/api/src/feature/meeting/entity/vote/vote.repository.ts
+++ b/packages/api/src/feature/meeting/entity/vote/vote.repository.ts
@@ -14,9 +14,9 @@ import {
   sql,
 } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
 import logger from "@sparcs-clubs/api/common/util/logger";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import {
   MeetingAgendaVote,
   MeetingMapping,

--- a/packages/api/src/feature/meeting/meeting.module.ts
+++ b/packages/api/src/feature/meeting/meeting.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import UserModule from "../user/user.module";
 import { AgendaModule } from "./agenda/agenda.module";

--- a/packages/api/src/feature/meeting/meeting.repository.ts
+++ b/packages/api/src/feature/meeting/meeting.repository.ts
@@ -1,7 +1,6 @@
 import { HttpException, HttpStatus, Inject, Injectable } from "@nestjs/common";
 import { and, count, eq, gte, isNull, lt, max, not, sql } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
 import { ApiMee012ResponseOk } from "@clubs/interface/api/meeting/apiMee012";
 import {
@@ -11,6 +10,7 @@ import {
 
 import logger from "@sparcs-clubs/api/common/util/logger";
 import { getKSTDate } from "@sparcs-clubs/api/common/util/util";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import {
   Meeting,
   MeetingAgenda,

--- a/packages/api/src/feature/notice/notice.module.ts
+++ b/packages/api/src/feature/notice/notice.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { ScheduleModule } from "@nestjs/schedule";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import { NoticeController } from "./controller/notice.controller";
 import { NoticeRepository } from "./repository/notice.repository";

--- a/packages/api/src/feature/promotional-printing/promotional-printing.module.ts
+++ b/packages/api/src/feature/promotional-printing/promotional-printing.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
 
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 import ClubModule from "@sparcs-clubs/api/feature/club/club.module";
 
 import { PromotionalPrintingController } from "./controller/promotional-printing.controller";

--- a/packages/api/src/feature/promotional-printing/repository/promotional-printing-order-size.repository.ts
+++ b/packages/api/src/feature/promotional-printing/repository/promotional-printing-order-size.repository.ts
@@ -1,8 +1,9 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { eq } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
-import { PromotionalPrintingOrderSize } from "src/drizzle/schema/promotional-printing.schema";
+
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import { PromotionalPrintingOrderSize } from "@sparcs-clubs/api/drizzle/schema/promotional-printing.schema";
 
 import type { FindPromotionalPrintingOrderSizeBypromotionalPrintingOrderIdReturn } from "../dto/promotional-printing.dto";
 

--- a/packages/api/src/feature/promotional-printing/repository/promotional-printing-order.repository.ts
+++ b/packages/api/src/feature/promotional-printing/repository/promotional-printing-order.repository.ts
@@ -1,15 +1,15 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, count, desc, eq, gte, lte } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
-import {
-  PromotionalPrintingOrder,
-  PromotionalPrintingOrderSize,
-} from "src/drizzle/schema/promotional-printing.schema";
 
 import { PromotionalPrintingOrderStatusEnum as Status } from "@clubs/interface/common/enum/promotionalPrinting.enum";
 
 import logger from "@sparcs-clubs/api/common/util/logger";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import {
+  PromotionalPrintingOrder,
+  PromotionalPrintingOrderSize,
+} from "@sparcs-clubs/api/drizzle/schema/promotional-printing.schema";
 import { Student } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 
 import type {

--- a/packages/api/src/feature/rental/rental.module.ts
+++ b/packages/api/src/feature/rental/rental.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import { RentalController } from "./controller/rental.controller";
 import { RentalObjectRepository } from "./repository/rental.rental-object.repository";

--- a/packages/api/src/feature/rental/repository/rental.rental-object.repository.ts
+++ b/packages/api/src/feature/rental/repository/rental.rental-object.repository.ts
@@ -1,13 +1,14 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, count, eq, gt, isNull, lt, or } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
+
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import {
   RentalEnum,
   RentalObject,
   RentalOrder,
   RentalOrderItemD,
-} from "src/drizzle/schema/rental.schema";
+} from "@sparcs-clubs/api/drizzle/schema/rental.schema";
 
 @Injectable()
 export class RentalObjectRepository {

--- a/packages/api/src/feature/rental/repository/rental.rental-order.repository.ts
+++ b/packages/api/src/feature/rental/repository/rental.rental-order.repository.ts
@@ -1,8 +1,8 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { count, eq } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import { ClubOld } from "@sparcs-clubs/api/drizzle/schema/club.schema";
 import {
   RentalEnum,

--- a/packages/api/src/feature/rental/repository/rental.rental-service.repository.ts
+++ b/packages/api/src/feature/rental/repository/rental.rental-service.repository.ts
@@ -1,17 +1,18 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, count, eq, gte, isNull, lte } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
-import { ClubOld } from "src/drizzle/schema/club.schema";
+
+import { RentalOrderStatusEnum } from "@clubs/interface/common/enum/rental.enum";
+
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
+import { ClubOld } from "@sparcs-clubs/api/drizzle/schema/club.schema";
 import {
   RentalEnum,
   RentalObject,
   RentalOrder,
   RentalOrderItemD,
-} from "src/drizzle/schema/rental.schema";
-import { Student } from "src/drizzle/schema/user.schema";
-
-import { RentalOrderStatusEnum } from "@clubs/interface/common/enum/rental.enum";
+} from "@sparcs-clubs/api/drizzle/schema/rental.schema";
+import { Student } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 
 interface Period {
   desiredStart?: Date;

--- a/packages/api/src/feature/semester/semester.module.ts
+++ b/packages/api/src/feature/semester/semester.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import { SemesterController } from "./controller/semester.controller";
 import { ActivityDeadlinePublicService } from "./publicService/activity.deadline.public.service";

--- a/packages/api/src/feature/user/privacy-policy/privacy-policy.module.ts
+++ b/packages/api/src/feature/user/privacy-policy/privacy-policy.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
+
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 
 import PrivacyPolicyController from "./privacy-policy.controller";
 import PrivacyPolicyRepository from "./privacy-policy.repository";

--- a/packages/api/src/feature/user/privacy-policy/privacy-policy.repository.ts
+++ b/packages/api/src/feature/user/privacy-policy/privacy-policy.repository.ts
@@ -1,8 +1,8 @@
 import { HttpException, HttpStatus, Inject, Injectable } from "@nestjs/common";
 import { and, eq, isNull } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import { UserPrivacyPolicyAgreement } from "@sparcs-clubs/api/drizzle/schema/user.schema";
 
 @Injectable()

--- a/packages/api/src/feature/user/repository/user.endpoint.repository.ts
+++ b/packages/api/src/feature/user/repository/user.endpoint.repository.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
+
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 
 @Injectable()
 export class UserEndpointRepository {

--- a/packages/api/src/feature/user/repository/user.repository.ts
+++ b/packages/api/src/feature/user/repository/user.repository.ts
@@ -1,16 +1,16 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, eq, gte, isNull, lte, or } from "drizzle-orm";
 import { MySql2Database } from "drizzle-orm/mysql2";
-import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
+
+import logger from "@sparcs-clubs/api/common/util/logger";
+import { takeOne } from "@sparcs-clubs/api/common/util/util";
+import { DrizzleAsyncProvider } from "@sparcs-clubs/api/drizzle/drizzle.provider";
 import {
   Department,
   Student,
   StudentT,
   User,
-} from "src/drizzle/schema/user.schema";
-
-import logger from "@sparcs-clubs/api/common/util/logger";
-import { takeOne } from "@sparcs-clubs/api/common/util/util";
+} from "@sparcs-clubs/api/drizzle/schema/user.schema";
 
 @Injectable()
 export default class UserRepository {

--- a/packages/api/src/feature/user/user.module.ts
+++ b/packages/api/src/feature/user/user.module.ts
@@ -1,6 +1,6 @@
 import { Module } from "@nestjs/common";
-import { DrizzleModule } from "src/drizzle/drizzle.module";
 
+import { DrizzleModule } from "@sparcs-clubs/api/drizzle/drizzle.module";
 import ClubStudentTRepository from "@sparcs-clubs/api/feature/club/repository-old/club.club-student-t.repository";
 import UserRepository from "@sparcs-clubs/api/feature/user/repository/user.repository";
 

--- a/packages/eslint-config/base.mjs
+++ b/packages/eslint-config/base.mjs
@@ -22,7 +22,7 @@ import globals from "globals";
 import tseslint from "typescript-eslint"; // 👴
 
 // 커스텀 룰 추가하기
-import noDirectZodNumberRule from "./custom_rules/zod-number-rules.mjs";
+import eslintPluginZodCoerce from "./custom_rules/eslint-plugin-zod-coerce.mjs";
 // 이것도 서드파티이긴한데...
 const compat = new FlatCompat({});
 
@@ -127,10 +127,10 @@ export const baseConfig = tseslint.config(
   {
     name: "zod custom rules enforce coerce",
     plugins: {
-      "zod-rules": noDirectZodNumberRule,
+      "eslint-plugin-zod-coerce": eslintPluginZodCoerce,
     },
     rules: {
-      "zod-rules/no-direct-z-number": "error",
+      "eslint-plugin-zod-coerce/z-number": "error",
     },
   },
 );

--- a/packages/eslint-config/custom_rules/eslint-plugin-zod-coerce.mjs
+++ b/packages/eslint-config/custom_rules/eslint-plugin-zod-coerce.mjs
@@ -2,9 +2,9 @@
 /**
  * @type {import("eslint").ESLint.Plugin}
  */
-const zodCoerceRule = {
+const eslintPluginZodCoerce = {
   rules: {
-    "no-direct-z-number": {
+    "z-number": {
       meta: {
         type: "problem",
         fixable: "code",
@@ -38,7 +38,7 @@ const zodCoerceRule = {
         };
       },
     },
-  }
+  },
 };
 
-export default zodCoerceRule;
+export default eslintPluginZodCoerce;

--- a/packages/eslint-config/nest-js.mjs
+++ b/packages/eslint-config/nest-js.mjs
@@ -9,7 +9,9 @@ export const nestJsConfig = [
   {
     name: "nestJS settings",
     files: ["**/*.ts"],
-    plugins: { jest: eslintPluginJest },
+    plugins: {
+      jest: eslintPluginJest,
+    },
     languageOptions: {
       globals: eslintPluginJest.environments.globals.globals,
     },
@@ -24,6 +26,24 @@ export const nestJsConfig = [
       "jest/no-identical-title": "error",
       "jest/prefer-to-have-length": "warn",
       "jest/valid-expect": "error",
+    },
+  },
+  {
+    name: "api-specific import rules",
+    files: ["**/*.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["src/*", "src/**/*"],
+              message:
+                "Importing directly from the src directory is prohibited. Please use the relative path or path alias defined in `tsconfig.json`.",
+            },
+          ],
+        },
+      ],
     },
   },
 ];

--- a/packages/eslint-config/nest-js.mjs
+++ b/packages/eslint-config/nest-js.mjs
@@ -37,7 +37,7 @@ export const nestJsConfig = [
         {
           patterns: [
             {
-              group: ["src/*", "src/**/*"],
+              group: ["src/**/*"],
               message:
                 "Importing directly from the src directory is prohibited. Please use the relative path or path alias defined in `tsconfig.json`.",
             },


### PR DESCRIPTION
# 📌 요약 \*
api 패키지에서 'src/*"를 차단하는 린트 추가함
It closes #issue_number

- 린트 규칙에 맞춰서 "src/*"->"@clubs-sparcs/api/*"로 수정

