### PR TITLE
TU-167 "move to activity report page" button and "link copy" button to PastActivityReportModal

### DIFF
--- a/packages/web/src/features/register-club/components/activity-report/PastActivityReportModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/PastActivityReportModal.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { overlay } from "overlay-kit";
 import React, { useEffect, useState } from "react";
 
@@ -12,6 +13,7 @@ import Button from "@sparcs-clubs/web/common/components/Button";
 import ThumbnailPreviewList from "@sparcs-clubs/web/common/components/File/ThumbnailPreviewList";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
 import TextInput from "@sparcs-clubs/web/common/components/Forms/TextInput";
+import Icon from "@sparcs-clubs/web/common/components/Icon";
 import { ListItem } from "@sparcs-clubs/web/common/components/ListItem";
 import Modal from "@sparcs-clubs/web/common/components/Modal";
 import ConfirmModalContent from "@sparcs-clubs/web/common/components/Modal/ConfirmModalContent";
@@ -49,6 +51,7 @@ const PastActivityReportModal: React.FC<PastActivityReportModalProps> = ({
   viewOnly = false,
   clubId,
 }) => {
+  const router = useRouter();
   const queryClient = useQueryClient();
   const { data, isLoading, isError, refetch } = useGetActivityReport(
     profile,
@@ -142,11 +145,44 @@ const PastActivityReportModal: React.FC<PastActivityReportModalProps> = ({
     close();
   };
 
+  const handleOpenActivityReportPage = () => {
+    close();
+    router.push(`/manage-club/activity-report/${activityId}`);
+  };
+
   if (!data) return null;
 
   return (
     <Modal isOpen={isOpen} width="full">
       <AsyncBoundary isLoading={isLoading} isError={isError}>
+        <FlexWrapper style={{ height: 0, margin: 0, zIndex: 10 }}>
+          <FlexWrapper
+            direction="row"
+            gap={16}
+            style={{
+              position: "absolute",
+              right: 0,
+            }}
+          >
+            <Button
+              style={{ padding: "8px" }}
+              onClick={() => {
+                navigator.clipboard.writeText(
+                  `${window.location.origin}/manage-club/activity-report/${activityId}`,
+                );
+                alert("활동보고서 주소가 클립보드에 복사 되었습니다!");
+              }}
+            >
+              <Icon type="link_variant" size={16} color="white" />
+            </Button>
+            <Button
+              style={{ padding: "8px" }}
+              onClick={handleOpenActivityReportPage}
+            >
+              <Icon type="open_in_new" size={16} color="white" />
+            </Button>
+          </FlexWrapper>
+        </FlexWrapper>
         <FlexWrapper gap={20} direction="column">
           {!isExecutive &&
             data.activityStatusEnumId === ActivityStatusEnum.Rejected &&


### PR DESCRIPTION
# 📌 요약 \*
활동보고서 모달에 활동보고서 페이지로 가는 버튼과 그 링크를 복사할 수 있는 버튼을 추가


## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: X
2. Figma: https://www.figma.com/design/gm0BeqvuY5dsA86XyRgEc3/Clubs?node-id=5232-68890&t=rfjxMf0ULRIYcCqL-0


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 
<img width="1440" alt="스크린샷 2025-04-28 오전 12 30 31" src="https://github.com/user-attachments/assets/83c43f94-a256-437d-91b9-feb22edb052d" />

1. 집행부원 동아리 신청 확인 페이지 (아래로 스크롤 후 활동보고서 하나 클릭) : http://localhost:3000/executive/register-club/285
