### PR TITLE
[TU-232] 프론트엔드 mock 모드 에러 수정

### DIFF
--- a/packages/web/src/features/activity-report/services/useGetActivityAvailable.ts
+++ b/packages/web/src/features/activity-report/services/useGetActivityAvailable.ts
@@ -1,5 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 
+import {
+  ActivityStatusEnum,
+  ActivityTypeEnum,
+} from "@clubs/domain/activity/activity";
+
 import apiAct021, {
   ApiAct021RequestQuery,
   ApiAct021ResponseOk,
@@ -29,8 +34,18 @@ defineAxiosMock(mock => {
     200,
     {
       activities: [
-        { id: 1, name: "활동보고서1" },
-        { id: 2, name: "활동보고서1" },
+        {
+          id: 1,
+          name: "활동보고서1",
+          activityStatusEnum: ActivityStatusEnum.Applied,
+          activityTypeEnum: ActivityTypeEnum.matchedExternalActivity,
+          club: { id: 1, name: "동아리1" },
+          chargedExecutive: { id: 1, name: "이재현" },
+          commentedExecutive: { id: 1, name: "이재현" },
+          commentedAt: new Date("2024-01-01"),
+          editedAt: new Date("2024-01-01"),
+          updatedAt: new Date("2024-01-01"),
+        },
       ],
     },
   ]);

--- a/packages/web/src/features/manage-club/funding/services/useGetFundingDeadline.ts
+++ b/packages/web/src/features/manage-club/funding/services/useGetFundingDeadline.ts
@@ -27,6 +27,8 @@ defineAxiosMock(mock => {
         id: 1,
         year: 2023,
         name: "여름가을",
+        semester: [{ id: 15 }, { id: 16 }, { id: 17 }],
+        activityDurationTypeEnum: [1],
         startTerm: new Date("2024-07-01"),
         endTerm: new Date("2024-12-30"),
       },

--- a/packages/web/src/lib/_axios/axiosMockInterceptor.ts
+++ b/packages/web/src/lib/_axios/axiosMockInterceptor.ts
@@ -57,15 +57,6 @@ export const mockResponseInterceptor = {
     return response;
   },
   onRejected(error: AxiosError) {
-    if (env.NEXT_PUBLIC_API_MOCK_MODE) {
-      log.debug(
-        `Error from ${error.config?.method} ${error.config?.url}:\n${JSON.stringify(
-          error.response?.data,
-          null,
-          2,
-        )}`,
-      );
-    }
     return Promise.reject(error);
   },
 };

--- a/packages/web/src/lib/_axios/axiosMockInterceptor.ts
+++ b/packages/web/src/lib/_axios/axiosMockInterceptor.ts
@@ -1,4 +1,4 @@
-import { AxiosError, InternalAxiosRequestConfig } from "axios";
+import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 import log from "loglevel";
 
 import { env } from "@sparcs-clubs/web/env";
@@ -9,10 +9,11 @@ export const BASE_URL = env.NEXT_PUBLIC_API_URL ?? "";
 const mockInterceptor = {
   async onFulfilled(config: InternalAxiosRequestConfig) {
     const responseConfig = { ...config };
-    try {
-      const parsedUrl = new URL(config.url ?? "");
 
-      if (parsedUrl.host != null) {
+    try {
+      const parsedUrl = new URL(config.url ?? "", BASE_URL);
+
+      if (parsedUrl.host == null) {
         return responseConfig;
       }
     } catch (error) {
@@ -38,6 +39,33 @@ const mockInterceptor = {
     return responseConfig;
   },
   onRejected(error: AxiosError) {
+    return Promise.reject(error);
+  },
+};
+
+export const mockResponseInterceptor = {
+  onFulfilled(response: AxiosResponse) {
+    if (env.NEXT_PUBLIC_API_MOCK_MODE) {
+      log.debug(
+        `Response from ${response.config.method} ${response.config.url}:\n${JSON.stringify(
+          response.data,
+          null,
+          2,
+        )}`,
+      );
+    }
+    return response;
+  },
+  onRejected(error: AxiosError) {
+    if (env.NEXT_PUBLIC_API_MOCK_MODE) {
+      log.debug(
+        `Error from ${error.config?.method} ${error.config?.url}:\n${JSON.stringify(
+          error.response?.data,
+          null,
+          2,
+        )}`,
+      );
+    }
     return Promise.reject(error);
   },
 };

--- a/packages/web/src/lib/axios.ts
+++ b/packages/web/src/lib/axios.ts
@@ -7,7 +7,9 @@ import { env } from "@sparcs-clubs/web/env";
 
 import tokenInterceptor from "./_axios/axiosAuthTokenInterceptor";
 import errorInterceptor from "./_axios/axiosErrorInterceptor";
-import mockInterceptor from "./_axios/axiosMockInterceptor";
+import mockInterceptor, {
+  mockResponseInterceptor,
+} from "./_axios/axiosMockInterceptor";
 
 // Timezone 설정
 const TIMEZONE = "Asia/Seoul";
@@ -86,6 +88,11 @@ axiosClient.interceptors.request.use(
 );
 
 axiosClient.interceptors.response.use(
+  mockResponseInterceptor.onFulfilled,
+  mockResponseInterceptor.onRejected,
+);
+
+axiosClient.interceptors.response.use(
   errorInterceptor.onFulfilled,
   errorInterceptor.onRejected,
 );
@@ -122,6 +129,11 @@ axiosClientWithAuth.interceptors.request.use(
 axiosClientWithAuth.interceptors.request.use(
   tokenInterceptor.onFulfilled,
   tokenInterceptor.onRejected,
+);
+
+axiosClientWithAuth.interceptors.response.use(
+  mockResponseInterceptor.onFulfilled,
+  mockResponseInterceptor.onRejected,
 );
 
 axiosClientWithAuth.interceptors.response.use(


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- mock interceptor에서 계속 에러 걸려서 실패하던 로직 조금 수정했습니다
- mock 실행 시 mock response data를 콘솔에서 확인할 수 있도록 로거 추가했습니다

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 
<img width="511" alt="image" src="https://github.com/user-attachments/assets/e5e1d052-64b8-45cc-a6fe-98a3de1932dc" />

