### PR TITLE
[TU-288] 지도교수 관련 오류 수정

### DIFF
--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -1110,7 +1110,7 @@ export default class ActivityService {
         createdAt: e.createdAt,
       })),
       updatedAt: activity.editedAt,
-      professorApprovedAt: activity.commentedAt,
+      professorApprovedAt: activity.professorApprovedAt,
       editedAt: activity.editedAt,
       commentedAt: activity.commentedAt,
     };

--- a/packages/web/src/common/providers/AuthContext.tsx
+++ b/packages/web/src/common/providers/AuthContext.tsx
@@ -13,6 +13,8 @@ import React, {
 } from "react";
 import { Cookies } from "react-cookie";
 
+import { UserTypeEnum } from "@clubs/interface/common/enum/user.enum";
+
 import { LOCAL_STORAGE_KEY } from "@sparcs-clubs/web/constants/localStorage";
 import patchNoteList from "@sparcs-clubs/web/constants/patchNote";
 import {
@@ -34,7 +36,7 @@ import postUserAgree from "../services/postUserAgree";
 export type Profile = {
   id: number;
   name: string;
-  type: string;
+  type: UserTypeEnum;
   email?: string;
 };
 interface AuthContextType {

--- a/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -105,10 +105,25 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
     profile.type === UserTypeEnum.Executive;
 
   const navigateToActivityReportList = () => {
-    if (profile.type === UserTypeEnum.Executive) {
-      router.back();
-    } else {
-      router.push("/manage-club/activity-report");
+    const profileType: UserTypeEnum = profile.type;
+    switch (profileType) {
+      case UserTypeEnum.Executive:
+        router.back();
+        break;
+      case UserTypeEnum.Professor:
+        router.push("/manage-club/");
+        break;
+      case UserTypeEnum.Master:
+      case UserTypeEnum.Doctor:
+      case UserTypeEnum.Employee:
+      case UserTypeEnum.Undergraduate:
+        router.push("/manage-club/activity-report");
+        break;
+      default: {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const exhaustiveCheck: never = profileType;
+        router.push("/manage-club/activity-report");
+      }
     }
   };
 


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->
지도교수 관련 오류 수정

# 버그 상황
1. stage에서 지도교수님이 활동보고서를 개별 승인 후, 목록으로 돌아가기 버튼을 클릭하면 로그아웃됩니다. 일괄 승인 시에는 문제가 발생하지 않습니다.~~

2. stage에서는 집행부가 승인을 하면 지도교수 승인란이 승인으로 변경되는 오류가 남아있는데, 해당 오류가 발생한 활동보고서를 지도교수님이 승인하실 수 없습니다.~~

3. stage에서 지도교수님이 승인하셔도 승인란이 대기로 남아있으며 승인버튼이 활상화되어 있습니다.~~


# 원인 및 수정

1. 목록으로 돌아가기 버튼 클릭 시 돌아가는 페이지의 링크가 잘못되어있었습니다. → 수정 완료
2. api로 리턴하는 값에 오타가 있어 승인 상태가 올바르게 반영되지 않습니다 → 수정 완료


## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
https://www.notion.so/sparcs/stage-1ebc25603b0b80d58fa4ea10eaa116ea?pvs=4

