### PR TITLE
[TU-244] 지도교수 승인과 수정 사이의 관계 해결

### DIFF
--- a/packages/api/src/feature/activity/service/activity.service.new.ts
+++ b/packages/api/src/feature/activity/service/activity.service.new.ts
@@ -373,7 +373,7 @@ export default class ActivityService {
         club: { id: activity.club.id },
         editedAt: new Date(),
         professorApprovedAt: undefined,
-        commentedAt: new Date(),
+        commentedAt: undefined,
         commentedExecutive: undefined,
       }),
     );
@@ -1050,7 +1050,7 @@ export default class ActivityService {
         createdAt: e.createdAt,
       })),
       updatedAt: activity.editedAt,
-      professorApprovedAt: activity.commentedAt,
+      professorApprovedAt: activity.professorApprovedAt,
       editedAt: activity.editedAt,
       commentedAt: activity.commentedAt,
     };

--- a/packages/web/src/features/activity-report/hooks/useGetActivityReportDetail.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetActivityReportDetail.ts
@@ -57,9 +57,19 @@ const useGetActivityReportDetail = (
         if (!hasProfessor) {
           return null;
         }
-        return activityReport.professorApprovedAt !== null
-          ? ProfessorApprovalEnum.Approved
-          : ProfessorApprovalEnum.Pending;
+
+        if (!activityReport.professorApprovedAt) {
+          return ProfessorApprovalEnum.Pending;
+        }
+
+        if (
+          activityReport.editedAt &&
+          activityReport.editedAt > activityReport.professorApprovedAt
+        ) {
+          return ProfessorApprovalEnum.Pending;
+        }
+
+        return ProfessorApprovalEnum.Approved;
       })(),
       professorApprovedAt:
         activityReport.professorApprovedAt !== null


### PR DESCRIPTION
view 에서 editedAt과 professorApprovedAt을 비교하도록 프론트 수정, update에서 professorApprovedAt을 수정하지 않도록 수정했습니다.
집행부나 다른 로직에서 잘 작동하는 지도 보아야 합니다.
선택적 지도교수에서도 잘 되는지도 테스트 필요합니다.