### PR TITLE
[TU-263] 활보 기간 입력 모달 스크롤 수정

### DIFF
--- a/packages/web/src/features/register-club/components/activity-report/EditActivityTermModal.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/EditActivityTermModal.tsx
@@ -81,7 +81,11 @@ const EditActivityTermModal: React.FC<EditActivityTermModalProps> = ({
           <FlexWrapper
             direction="column"
             gap={12}
-            style={{ width: "min(600px, 80vw)", height: "min(300px, 80vh)" }}
+            style={{
+              width: "min(600px, 80vw)",
+              height: "min(300px, 80vh)",
+              overflowY: "scroll",
+            }}
           >
             {fields.map((field, index) => (
               <FlexWrapper
@@ -161,7 +165,13 @@ const EditActivityTermModal: React.FC<EditActivityTermModalProps> = ({
               </Typography>
             )}
             {isSomethingEmpty && (
-              <Typography fw="MEDIUM" fs={12} lh={18} color="RED.600">
+              <Typography
+                fw="MEDIUM"
+                fs={12}
+                lh={18}
+                color="RED.600"
+                style={{ marginBottom: fields.length === 4 ? "60px" : "0px" }}
+              >
                 기간을 입력하거나 해당 항목을 삭제해주세요.
               </Typography>
             )}


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 활보 기간 입력 모달에서 기간이 5개 이상이 될 경우 UI가 깨지는 문제 해결
- 기간이 4개일 때 날짜 선택 overlay 일부가 잘리는 문제 해결

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
AS-IS

https://github.com/user-attachments/assets/e7cd4adc-135b-4569-9d77-c42853f3467a




TO-BE

https://github.com/user-attachments/assets/a2ee5e5e-09dc-4843-8331-3b2ed6bdc9b0



프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/manage-club/activity-report/create
