### PR TITLE
[TU-246] 과거활보 수정삭제 버튼 삭제, 지도교수 승인 상태 초기화 로직 수정

### DIFF
--- a/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/ActivityReportDetailFrame.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from "next/navigation";
 import { overlay } from "overlay-kit";
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 
 import { UserTypeEnum } from "@clubs/interface/common/enum/user.enum";
@@ -180,6 +180,19 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
     });
   }, [approveActivityReport, id]);
 
+  const isPastActivityReport = useMemo(
+    () =>
+      data.durations?.every(duration => {
+        if (!activityDeadline?.targetTerm || !duration.endTerm) return true;
+
+        return (
+          new Date(duration.endTerm) <=
+          new Date(activityDeadline.targetTerm.startTerm)
+        );
+      }),
+    [activityDeadline, data.durations],
+  );
+
   if (isError) {
     return <NotFound />;
   }
@@ -313,7 +326,8 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
             isError={isErrorDeadline}
           >
             {profile.type === UserTypeEnum.Undergraduate &&
-              activityDeadline?.isEditable && (
+              activityDeadline?.isEditable &&
+              !isPastActivityReport && (
                 <FlexWrapper gap={12}>
                   <Button type="default" onClick={handleDelete}>
                     삭제
@@ -324,7 +338,8 @@ const ActivityReportDetailFrame: React.FC<ActivityReportDetailFrameProps> = ({
                 </FlexWrapper>
               )}
             {profile.type === UserTypeEnum.Professor &&
-              activityDeadline?.canApprove && (
+              activityDeadline?.canApprove &&
+              !isPastActivityReport && (
                 <Button
                   type={data.professorApprovedAt ? "disabled" : "default"}
                   onClick={handleProfessorApproval}

--- a/packages/web/src/features/activity-report/hooks/useGetActivityReportDetail.ts
+++ b/packages/web/src/features/activity-report/hooks/useGetActivityReportDetail.ts
@@ -62,13 +62,6 @@ const useGetActivityReportDetail = (
           return ProfessorApprovalEnum.Pending;
         }
 
-        if (
-          activityReport.editedAt &&
-          activityReport.editedAt > activityReport.professorApprovedAt
-        ) {
-          return ProfessorApprovalEnum.Pending;
-        }
-
         return ProfessorApprovalEnum.Approved;
       })(),
       professorApprovedAt:


### PR DESCRIPTION
…or past activity

# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 과거 활보 상세조회에서 수정, 삭제 버튼이 보이는 문제 해결(IsPastActivityReport를 체크하는 로직 확인 필요!)
- 지도교수 승인 후 대표자가 다시 수정했을 때에도 지도교수 승인 상태는 초기화되면 안됨 -> 해당 이슈 수정 완료

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록:  
1. 활동 보고서 상세조회: http://localhost:3000/manage-club/activity-report/{id}

1. 동아리 상세조회 페이지: http://localhost:3000/clubs/1
