### PR TITLE
[TU-233] 집행부원 활보 동아리별 상세 조회 페이지 마진 수정

### DIFF
--- a/packages/web/src/features/activity-report/components/executive/ExecutiveCurrentActivityReportSection.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutiveCurrentActivityReportSection.tsx
@@ -63,7 +63,7 @@ const ExecutiveCurrentActivityReportSection: React.FC<
   }, [selectedActivityIds, selectedActivityInfos]);
 
   return (
-    <FoldableSectionTitle childrenMargin="20px" title="신규 활동 보고서">
+    <FoldableSectionTitle childrenMargin="30px" title="신규 활동 보고서">
       <AsyncBoundary isLoading={isLoading} isError={isError}>
         <FlexWrapper direction="column" gap={20}>
           {data?.items && data.items.length > 0 && (

--- a/packages/web/src/features/activity-report/components/executive/ExecutivePastActivityReportSection.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutivePastActivityReportSection.tsx
@@ -22,13 +22,14 @@ const ExecutivePastActivityReportSection: React.FC<
   } = useGetExecutiveClubActivities(+clubId);
 
   return (
-    <FoldableSectionTitle title="과거 활동 보고서">
+    <FoldableSectionTitle title="과거 활동 보고서" childrenMargin="30px">
       <AsyncBoundary isLoading={isLoading} isError={isError}>
-        <FlexWrapper direction="column" gap={40}>
+        <FlexWrapper direction="column" gap={30}>
           {dataList.map(data => (
             <FoldableSection
               key={data.term.id}
               title={`${data.term.year}년 ${data.term.name}학기 (총 ${data.activities?.items ? data.activities.items.length : 0}개)`}
+              childrenMargin="20px"
             >
               {data.activities == null ? (
                 <AsyncBoundary isLoading={false} isError />


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 집행부원 활보 동아리별 상세 조회 페이지 마진을 디자인에 맞게 수정합니다

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/clubs/1
