### PR TITLE
[TU-279] 동아리 대표자 변경, 활보, 지원금 마이너한 수정사항들

### DIFF
--- a/packages/web/src/features/manage-club/components/ChangeRepresentativeInfo.tsx
+++ b/packages/web/src/features/manage-club/components/ChangeRepresentativeInfo.tsx
@@ -91,8 +91,8 @@ const ChangeRepresentativeInfo: React.FC<ChangeRepresentativeProps> = ({
             거절되지 않을 경우 자동으로 취소됩니다
             <br />
             <br />
-            만약 요청 받으신 분의 &apos;마이페이지&apos;에서 대표자 변경 안내
-            팝업이 보이지 않는 다면 채널톡으로 문의주세요!
+            만약 요청받으신 분의 &apos;마이페이지&apos;에서 대표자 변경 안내
+            팝업이 보이지 않는다면 채널톡으로 문의해 주세요!
           </Typography>
         )}
       </FlexWrapper>

--- a/packages/web/src/features/manage-club/components/ChangeRepresentativeInfo.tsx
+++ b/packages/web/src/features/manage-club/components/ChangeRepresentativeInfo.tsx
@@ -89,6 +89,10 @@ const ChangeRepresentativeInfo: React.FC<ChangeRepresentativeProps> = ({
           <Typography fw="REGULAR" fs={16} lh={20}>
             대표자 변경 요청을 취소할 수 있으며, 요청이 3일 내로 승인 또는
             거절되지 않을 경우 자동으로 취소됩니다
+            <br />
+            <br />
+            만약 요청 받으신 분의 &apos;마이페이지&apos;에서 대표자 변경 안내
+            팝업이 보이지 않는 다면 채널톡으로 문의주세요!
           </Typography>
         )}
       </FlexWrapper>

--- a/packages/web/src/features/manage-club/funding/frames/FundingInfoFrame.tsx
+++ b/packages/web/src/features/manage-club/funding/frames/FundingInfoFrame.tsx
@@ -1,3 +1,4 @@
+import { addDays, subDays } from "date-fns";
 import React, { useCallback } from "react";
 import { useFormContext } from "react-hook-form";
 import styled from "styled-components";
@@ -124,9 +125,13 @@ const FundingInfoFrame: React.FC<{ clubId: number }> = ({ clubId }) => {
                   label="지출 일자"
                   placeholder="20XX.XX.XX"
                   minDate={
-                    fundingDeadline.targetDuration.startTerm ?? undefined
+                    addDays(fundingDeadline.targetDuration.startTerm, 1) ??
+                    undefined
                   }
-                  maxDate={fundingDeadline.targetDuration.endTerm ?? undefined}
+                  maxDate={
+                    subDays(fundingDeadline.targetDuration.endTerm, 1) ??
+                    undefined
+                  }
                   // TODO: mindate 와 maxdate 활동 기간 안에 포함되는 지 확인
                   selected={value}
                   onChange={(data: Date | null) => {


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 지원금 신청 페이지 데이터 피커 날짜 제한 걸기(이번 지원금 기간: 2024.12.21~2025.06.13)
- 활보 운영위원회 회원들 조회 가능하게 열기 (운영위원회는 학생인데 집행부 페이지의 활보 목록만 조회 가능하게 열기.. 대신 승인 반려 버튼은 안되게 막기) --> 요건 일단 어떻게 할지 확인 중이라 아직 작업 전!
- TU-278에서 대표자 변경 관련 안내 메시지 추가한 것 커밋에 안 들어갔어서 그거 이 브랜치에 변경사항 추가함

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 운영위원회 활보 조회 부분 확인 중이라 아직 작업 전!


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/clubs/1
