### PR TITLE
[TU-287] 집행부원 활보 동아리별 페이지 페이지네이션 삭제, 검색 로직 프론트로 이전

### DIFF
--- a/packages/web/src/features/activity-report/components/executive/ExecutiveActivityChargedTable.tsx
+++ b/packages/web/src/features/activity-report/components/executive/ExecutiveActivityChargedTable.tsx
@@ -21,6 +21,7 @@ import ChargedActivityModalTable, {
 } from "./ChargedActivityModalTable";
 
 interface ExecutiveActivityChargedTableProps {
+  searchText: string;
   executives?: ApiAct023ResponseOk["executiveProgresses"];
 }
 
@@ -152,24 +153,36 @@ const columns = [
 
 const ExecutiveActivityChargedTable: React.FC<
   ExecutiveActivityChargedTableProps
-> = ({ executives = [] }) => {
+> = ({ searchText, executives = [] }) => {
   const table = useReactTable({
     data: executives,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    enableSorting: true,
+    state: {
+      globalFilter: searchText,
+    },
+    enableSorting: false,
   });
 
   const totalCount = executives.length;
 
+  let countString = `총 ${totalCount}개`;
+  if (table.getRowModel().rows.length !== totalCount) {
+    countString = `검색 결과 ${table.getRowModel().rows.length}개 / 총 ${totalCount}개`;
+  }
+
   return (
-    <Table
-      count={totalCount}
-      table={table}
-      minWidth={800}
-      rowLink={row => `/executive/activity-report/charged/${row.executiveId}`}
-    />
+    <FlexWrapper direction="column" gap={8}>
+      <Typography fs={16} lh={20} style={{ flex: 1, textAlign: "right" }}>
+        {countString}
+      </Typography>
+      <Table
+        table={table}
+        minWidth={800}
+        rowLink={row => `/executive/activity-report/charged/${row.executiveId}`}
+      />
+    </FlexWrapper>
   );
 };
 

--- a/packages/web/src/features/activity-report/frames/executive/ExecutiveActivityReportFrame.tsx
+++ b/packages/web/src/features/activity-report/frames/executive/ExecutiveActivityReportFrame.tsx
@@ -1,11 +1,9 @@
 import { overlay } from "overlay-kit";
 import { useCallback, useEffect, useState } from "react";
-import styled from "styled-components";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
 import Button from "@sparcs-clubs/web/common/components/Button";
 import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
-import Pagination from "@sparcs-clubs/web/common/components/Pagination";
 import SearchInput from "@sparcs-clubs/web/common/components/SearchInput";
 import ActivityReportStatistic from "@sparcs-clubs/web/features/activity-report/components/executive/ActivityReportStatistic";
 import ChargedChangeClubModalContent from "@sparcs-clubs/web/features/activity-report/components/executive/ChargedChangeClubModalContent";
@@ -14,33 +12,21 @@ import ExecutiveActivityChargedTable from "@sparcs-clubs/web/features/activity-r
 import ExecutiveActivityClubTable from "@sparcs-clubs/web/features/activity-report/components/executive/ExecutiveActivityClubTable";
 import useGetExecutiveActivities from "@sparcs-clubs/web/features/activity-report/services/executive/useGetExecutiveActivities";
 
-const TableWithPaginationWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
-`;
-
 const ExecutiveActivityReportFrame = () => {
   const [isClubView, setIsClubView] = useState<boolean>(
     window.history.state.isClubView ?? true,
   );
   const [searchText, setSearchText] = useState("");
-  const [tempSearchText, setTempSearchText] = useState(searchText);
 
   const [selectedClubIds, setSelectedClubIds] = useState<number[]>([]);
   const [selectedClubInfos, setSelectedClubInfos] = useState<
     ChargedChangeClubProps[]
   >([]);
 
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const limit = 10;
-
+  // TODO. 우선 급한대로 야매로 처리함 (추후에 페이지네이션 백에서 삭제하기)
   const { data, isLoading, isError } = useGetExecutiveActivities({
-    pageOffset: currentPage,
-    itemCount: limit,
-    clubName: isClubView ? searchText : undefined,
-    executiveName: !isClubView ? searchText : undefined,
+    pageOffset: 1,
+    itemCount: 150,
   });
 
   useEffect(() => {
@@ -75,14 +61,6 @@ const ExecutiveActivityReportFrame = () => {
       />
     ));
   }, [selectedClubIds, selectedClubInfos]);
-
-  useEffect(() => {
-    const debounce = setTimeout(() => {
-      setSearchText(tempSearchText);
-      setCurrentPage(1);
-    }, 500);
-    return () => clearTimeout(debounce);
-  }, [tempSearchText]);
 
   return (
     <AsyncBoundary isLoading={isLoading} isError={isError}>
@@ -124,8 +102,8 @@ const ExecutiveActivityReportFrame = () => {
       </FlexWrapper>
       <FlexWrapper direction="row" gap={16}>
         <SearchInput
-          searchText={tempSearchText}
-          handleChange={setTempSearchText}
+          searchText={searchText}
+          handleChange={setSearchText}
           placeholder={
             isClubView
               ? "동아리 이름을 입력해주세요"
@@ -141,28 +119,19 @@ const ExecutiveActivityReportFrame = () => {
           </Button>
         )}
       </FlexWrapper>
-      <TableWithPaginationWrapper>
-        {isClubView ? (
-          <>
-            <ExecutiveActivityClubTable
-              activities={data?.items}
-              total={data?.total ?? 0}
-              selectedClubIds={selectedClubIds}
-              setSelectedClubIds={setSelectedClubIds}
-            />
-            <Pagination
-              totalPage={Math.ceil((data?.total ?? 0) / limit)}
-              currentPage={currentPage}
-              limit={limit}
-              setPage={setCurrentPage}
-            />
-          </>
-        ) : (
-          <ExecutiveActivityChargedTable
-            executives={data?.executiveProgresses}
-          />
-        )}
-      </TableWithPaginationWrapper>
+      {isClubView ? (
+        <ExecutiveActivityClubTable
+          activities={data?.items}
+          searchText={searchText}
+          selectedClubIds={selectedClubIds}
+          setSelectedClubIds={setSelectedClubIds}
+        />
+      ) : (
+        <ExecutiveActivityChargedTable
+          executives={data?.executiveProgresses}
+          searchText={searchText}
+        />
+      )}
     </AsyncBoundary>
   );
 };


### PR DESCRIPTION
…rch logic to frontend

# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 활보 집행부원 페이지 동아리, 담당자 테이블에 `페이지네이션 넣고, 검색 로직 백으로 이전하고, 프론트에서 디바운싱` 처리한거 삭제함(롤백)

이유: 집행부원 사용자들이 불편하다함. 동아리 개수 얼마 안 되니까(<150) 다 보여주고 검색을 프론트에서 실시간으로 빠르게 처리하는게 편하다 함

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 백에서도 페이지네이션, 검색 로직 삭제하기 (@Engineer-HaMa)

<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 집행부원 활보 조회 페이지: http://localhost:3000/executive/activity-report
