### PR TITLE
[TU-305] 지원금 기간 관리 페이지 추가

### DIFF
--- a/packages/web/src/app/executive/funding/deadline/page.tsx
+++ b/packages/web/src/app/executive/funding/deadline/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { overlay } from "overlay-kit";
+import { useEffect, useState } from "react";
+
+import { UserTypeEnum } from "@clubs/interface/common/enum/user.enum";
+
+import Custom404 from "@sparcs-clubs/web/app/not-found";
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import IconButton from "@sparcs-clubs/web/common/components/Buttons/IconButton";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import PageHead from "@sparcs-clubs/web/common/components/PageHead";
+import LoginRequired from "@sparcs-clubs/web/common/frames/LoginRequired";
+import { useAuth } from "@sparcs-clubs/web/common/providers/AuthContext";
+import FundingDeadlineFormModal from "@sparcs-clubs/web/features/executive/funding/components/FundingDeadlineFormModal";
+import FundingDeadlineManagementPage from "@sparcs-clubs/web/features/executive/funding/components/FundingDeadlineSectionList";
+
+const ExecutiveFundingDeadline = () => {
+  const { isLoggedIn, login, profile } = useAuth();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (isLoggedIn !== undefined || profile !== undefined) {
+      setLoading(false);
+    }
+  }, [isLoggedIn, profile]);
+
+  if (loading) {
+    return <AsyncBoundary isLoading={loading} isError />;
+  }
+
+  if (!isLoggedIn) {
+    return <LoginRequired login={login} />;
+  }
+
+  if (profile?.type !== UserTypeEnum.Executive) {
+    return <Custom404 />;
+  }
+
+  const openFundingDeadlineModal = () => {
+    overlay.open(({ isOpen, close }) => (
+      <FundingDeadlineFormModal isOpen={isOpen} onClose={close} />
+    ));
+  };
+
+  return (
+    <FlexWrapper direction="column" gap={30}>
+      <PageHead
+        items={[{ name: "집행부원 대시보드", path: "/executive" }]}
+        title="지원금 기간 관리"
+        enableLast
+      />
+      <FlexWrapper direction="row" justify="flex-end">
+        <IconButton
+          type="default"
+          icon="add"
+          onClick={openFundingDeadlineModal}
+        >
+          지원금 기간 추가
+        </IconButton>
+      </FlexWrapper>
+      <FundingDeadlineManagementPage />
+    </FlexWrapper>
+  );
+};
+
+export default ExecutiveFundingDeadline;

--- a/packages/web/src/app/executive/funding/deadline/page.tsx
+++ b/packages/web/src/app/executive/funding/deadline/page.tsx
@@ -44,21 +44,21 @@ const ExecutiveFundingDeadline = () => {
   };
 
   return (
-    <FlexWrapper direction="column" gap={30}>
+    <FlexWrapper direction="column" gap={60}>
       <PageHead
         items={[{ name: "집행부원 대시보드", path: "/executive" }]}
         title="지원금 기간 관리"
+        action={
+          <IconButton
+            type="default"
+            icon="add"
+            onClick={openFundingDeadlineModal}
+          >
+            지원금 기간 추가
+          </IconButton>
+        }
         enableLast
       />
-      <FlexWrapper direction="row" justify="flex-end">
-        <IconButton
-          type="default"
-          icon="add"
-          onClick={openFundingDeadlineModal}
-        >
-          지원금 기간 추가
-        </IconButton>
-      </FlexWrapper>
       <FundingDeadlineManagementPage />
     </FlexWrapper>
   );

--- a/packages/web/src/features/executive/frames/ExecutiveDashboardFrame.tsx
+++ b/packages/web/src/features/executive/frames/ExecutiveDashboardFrame.tsx
@@ -36,6 +36,30 @@ const ExecutiveDashboardFrame = () => {
       </Banner>
       <ManageSemesterFrame />
       <ManageMemberFrame />
+
+      <FlexWrapper direction="column" gap={20}>
+        <SectionTitle>기간 관리</SectionTitle>
+        <DashboardSectionInner>
+          <FlexWrapper
+            direction="row"
+            gap={60}
+            style={{ justifyContent: "space-between" }}
+          >
+            <FlexWrapper direction="column" gap={12} style={{ flex: 1 }}>
+              <DashboardButton text="동아리 등록 기간" link="" />
+              <DashboardButton text="회원 등록 기간" link="" />
+            </FlexWrapper>
+            <FlexWrapper direction="column" gap={12} style={{ flex: 1 }}>
+              <DashboardButton text="활동 보고서 기간" link="" />
+              <DashboardButton
+                text="지원금 기간"
+                link="/executive/funding/deadline"
+              />
+            </FlexWrapper>
+          </FlexWrapper>
+        </DashboardSectionInner>
+      </FlexWrapper>
+
       <FlexWrapper
         direction="row"
         gap={60}

--- a/packages/web/src/features/executive/funding/components/FundingDeadlineFormModal.tsx
+++ b/packages/web/src/features/executive/funding/components/FundingDeadlineFormModal.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+
+import { FundingDeadlineEnum } from "@clubs/interface/common/enum/funding.enum";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import DateInput from "@sparcs-clubs/web/common/components/Forms/DateInput";
+import Modal from "@sparcs-clubs/web/common/components/Modal";
+import CancellableModalContent from "@sparcs-clubs/web/common/components/Modal/CancellableModalContent";
+import Select from "@sparcs-clubs/web/common/components/Select";
+import Typography from "@sparcs-clubs/web/common/components/Typography";
+import useCreateFundingDeadline from "@sparcs-clubs/web/features/executive/funding/services/useCreateFundingDeadline";
+import useGetActivityDurations from "@sparcs-clubs/web/features/executive/services/useGetActivityDurations";
+import { fundingDeadlineEnumToString } from "@sparcs-clubs/web/features/manage-club/funding/constants/fundingDeadlineEnumToString";
+
+interface FundingDeadlineFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const FundingDeadlineFormModal = ({
+  isOpen,
+  onClose,
+}: FundingDeadlineFormModalProps) => {
+  const [activityDId, setActivityDId] = useState<number | null>(null);
+  const [deadlineEnum, setDeadlineEnum] = useState<FundingDeadlineEnum | null>(
+    null,
+  );
+  const [startTerm, setStartTerm] = useState<Date | null>(null);
+  const [endTerm, setEndTerm] = useState<Date | null>(null);
+
+  const { mutate: createFundingDeadline } = useCreateFundingDeadline();
+  const { data, isLoading, isError } = useGetActivityDurations();
+
+  const handleSave = () => {
+    if (activityDId && deadlineEnum && startTerm && endTerm) {
+      createFundingDeadline({
+        activityDId,
+        deadlineEnum,
+        startTerm,
+        endTerm,
+      });
+      onClose();
+    }
+  };
+
+  return (
+    <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <Modal isOpen={isOpen}>
+        <CancellableModalContent
+          onConfirm={handleSave}
+          onClose={onClose}
+          confirmButtonText="저장"
+          closeButtonText="취소"
+          confirmDisabled={
+            data != null &&
+            (!activityDId || !deadlineEnum || !startTerm || !endTerm)
+          }
+        >
+          {data == null ? (
+            <AsyncBoundary isLoading={false} isError />
+          ) : (
+            <FlexWrapper direction="column" gap={20} style={{ width: "400px" }}>
+              <Typography fs={18} lh={24} fw="MEDIUM">
+                새 지원금 기간 추가
+              </Typography>
+              <Select
+                label="활동기간"
+                placeholder="활동기간을 선택해주세요"
+                value={activityDId}
+                onChange={e => setActivityDId(e)}
+                items={data.activityDurations.map(activityDuration => ({
+                  label: `${activityDuration.year}년 ${activityDuration.name} 활동기간`,
+                  value: activityDuration.id,
+                }))}
+              />
+
+              <Select
+                label="지원금 기간"
+                placeholder="지원금 기간을 선택해주세요"
+                value={deadlineEnum}
+                onChange={e => setDeadlineEnum(e as FundingDeadlineEnum)}
+                items={(
+                  Object.values(FundingDeadlineEnum).filter(
+                    value => typeof value === "number",
+                  ) as Array<FundingDeadlineEnum>
+                ).map((value: FundingDeadlineEnum) => ({
+                  label: fundingDeadlineEnumToString(value),
+                  value,
+                }))}
+              />
+
+              <FlexWrapper
+                direction="column"
+                gap={20}
+                style={{ textAlign: "left" }}
+              >
+                <DateInput
+                  label="시작일"
+                  selected={startTerm}
+                  onChange={(date: Date | null) => setStartTerm(date)}
+                />
+
+                <DateInput
+                  label="종료일"
+                  selected={endTerm}
+                  onChange={(date: Date | null) => setEndTerm(date)}
+                />
+              </FlexWrapper>
+            </FlexWrapper>
+          )}
+        </CancellableModalContent>
+      </Modal>
+    </AsyncBoundary>
+  );
+};
+
+export type { FundingDeadlineFormModalProps };
+export default FundingDeadlineFormModal;

--- a/packages/web/src/features/executive/funding/components/FundingDeadlineSection.tsx
+++ b/packages/web/src/features/executive/funding/components/FundingDeadlineSection.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import { ApiSem012ResponseOK } from "@clubs/interface/api/semester/apiSem012";
+import { ApiSem016ResponseOk } from "@clubs/interface/api/semester/apiSem016";
+
+import FoldableSection from "@sparcs-clubs/web/common/components/FoldableSection";
+
+import FundingDeadlineTable from "./FundingDeadlineTable";
+
+interface FundingDeadlineSectionProps {
+  activityDuration: ApiSem012ResponseOK["activityDurations"][number];
+  fundingDeadlines: ApiSem016ResponseOk | undefined;
+}
+
+const FundingDeadlineSection: React.FC<FundingDeadlineSectionProps> = ({
+  activityDuration,
+  fundingDeadlines,
+}) => {
+  if (!fundingDeadlines || fundingDeadlines.deadlines.length === 0) {
+    return null;
+  }
+
+  return (
+    <FoldableSection
+      key={activityDuration.id}
+      title={`${activityDuration.year}년 ${activityDuration.name} 활동기간`}
+      childrenMargin="20px"
+    >
+      <FundingDeadlineTable fundingDeadlines={fundingDeadlines} />
+    </FoldableSection>
+  );
+};
+
+export default FundingDeadlineSection;

--- a/packages/web/src/features/executive/funding/components/FundingDeadlineSectionList.tsx
+++ b/packages/web/src/features/executive/funding/components/FundingDeadlineSectionList.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import useGetActivityDurations from "@sparcs-clubs/web/features/executive/services/useGetActivityDurations";
+
+import useGetAllFundingDeadlines from "../hooks/useGetAllFundingDeadlines";
+import FundingDeadlineSection from "./FundingDeadlineSection";
+
+const FundingDeadlineSectionList: React.FC = () => {
+  const {
+    data: activityDurationsData,
+    isLoading: isActivityDurationsLoading,
+    isError: isActivityDurationsError,
+  } = useGetActivityDurations();
+
+  const {
+    data: allFundingDeadlinesData,
+    isLoading: isFundingDeadlinesLoading,
+    isError: isFundingDeadlinesError,
+  } = useGetAllFundingDeadlines(activityDurationsData?.activityDurations || []);
+
+  const isLoading = isActivityDurationsLoading || isFundingDeadlinesLoading;
+  const isError = isActivityDurationsError || isFundingDeadlinesError;
+
+  return (
+    <AsyncBoundary isLoading={isLoading} isError={isError}>
+      <FlexWrapper direction="column" gap={30}>
+        {allFundingDeadlinesData?.map(
+          ({ activityDuration, fundingDeadlines }) => (
+            <FundingDeadlineSection
+              key={activityDuration.id}
+              activityDuration={activityDuration}
+              fundingDeadlines={fundingDeadlines}
+            />
+          ),
+        )}
+      </FlexWrapper>
+    </AsyncBoundary>
+  );
+};
+
+export default FundingDeadlineSectionList;

--- a/packages/web/src/features/executive/funding/components/FundingDeadlineTable.tsx
+++ b/packages/web/src/features/executive/funding/components/FundingDeadlineTable.tsx
@@ -1,0 +1,103 @@
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { formatDate } from "date-fns";
+import { ko } from "date-fns/locale";
+import { useMemo } from "react";
+
+import { ApiSem016ResponseOk } from "@clubs/interface/api/semester/apiSem016";
+
+import TextButton from "@sparcs-clubs/web/common/components/Buttons/TextButton";
+import FlexWrapper from "@sparcs-clubs/web/common/components/FlexWrapper";
+import Table from "@sparcs-clubs/web/common/components/Table";
+import { fundingDeadlineEnumToString } from "@sparcs-clubs/web/features/manage-club/funding/constants/fundingDeadlineEnumToString";
+
+import useDeleteFundingDeadline from "../services/useDeleteFundingDeadline";
+
+interface ExecutiveFundingClubTableProps {
+  fundingDeadlines: ApiSem016ResponseOk;
+}
+
+const FundingDeadlineTable = ({
+  fundingDeadlines,
+}: ExecutiveFundingClubTableProps) => {
+  const {
+    mutate: deleteFundingDeadline,
+    isPending: isDeletingFundingDeadline,
+  } = useDeleteFundingDeadline();
+
+  const sortedDeadlines = useMemo(() => {
+    if (!fundingDeadlines?.deadlines) return [];
+    return [...fundingDeadlines.deadlines].sort(
+      (a, b) => b.startTerm.getTime() - a.startTerm.getTime(),
+    );
+  }, [fundingDeadlines?.deadlines]);
+
+  const handleDeleteFundingDeadline = (id: number) => {
+    const deadlineToDelete = sortedDeadlines.find(d => d.id === id);
+    if (!deadlineToDelete) return;
+
+    deleteFundingDeadline({
+      fundingDeadlineId: deadlineToDelete.id,
+    });
+  };
+
+  const actionsCellRenderer = (id: number) => (
+    <TextButton
+      text="삭제"
+      onClick={() => handleDeleteFundingDeadline(id)}
+      disabled={isDeletingFundingDeadline}
+    />
+  );
+
+  const columnHelper =
+    createColumnHelper<ApiSem016ResponseOk["deadlines"][number]>();
+  const columns = [
+    columnHelper.accessor("deadlineEnum", {
+      header: "구분",
+      cell: info => fundingDeadlineEnumToString(info.getValue()),
+      size: 125,
+    }),
+    columnHelper.accessor("startTerm", {
+      header: "시작일",
+      cell: info =>
+        info.getValue()
+          ? formatDate(info.getValue(), "yyyy-MM-dd (ccc)", { locale: ko })
+          : "-",
+      size: 150,
+      enableSorting: false,
+    }),
+    columnHelper.accessor("endTerm", {
+      header: "종료일",
+      cell: info =>
+        info.getValue()
+          ? formatDate(info.getValue(), "yyyy-MM-dd (ccc)", { locale: ko })
+          : "-",
+      size: 150,
+      enableSorting: false,
+    }),
+    columnHelper.display({
+      id: "actions",
+      header: "관리",
+      cell: ({ row }) => actionsCellRenderer(row.original.id),
+      size: 120,
+    }),
+  ];
+
+  const table = useReactTable({
+    data: sortedDeadlines,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    enableSorting: false,
+  });
+
+  return (
+    <FlexWrapper direction="column" gap={8}>
+      <Table count={sortedDeadlines.length} table={table} />
+    </FlexWrapper>
+  );
+};
+
+export default FundingDeadlineTable;

--- a/packages/web/src/features/executive/funding/hooks/useGetAllFundingDeadlines.ts
+++ b/packages/web/src/features/executive/funding/hooks/useGetAllFundingDeadlines.ts
@@ -1,0 +1,40 @@
+import { useQueries } from "@tanstack/react-query";
+
+import { ApiSem012ResponseOK } from "@clubs/interface/api/semester/apiSem012";
+import { apiSem016 } from "@clubs/interface/api/semester/apiSem016";
+
+import { defineAxiosMock } from "@sparcs-clubs/web/lib/axios";
+
+import { fundingDeadlinesQueryFn } from "../services/useGetFundingDeadlines";
+
+type ActivityDuration = ApiSem012ResponseOK["activityDurations"][number];
+
+const useGetAllFundingDeadlines = (activityDurations: ActivityDuration[]) => {
+  const queries = useQueries({
+    queries: activityDurations.map(activityDuration => ({
+      queryKey: [apiSem016.url, activityDuration.id],
+      queryFn: () =>
+        fundingDeadlinesQueryFn({ activityDId: activityDuration.id }),
+      enabled: activityDurations.length > 0,
+    })),
+  });
+
+  const isLoading = queries.some(query => query.isLoading);
+  const isError = queries.some(query => query.isError);
+  const data = queries.map((query, index) => ({
+    activityDuration: activityDurations[index],
+    fundingDeadlines: query.data,
+  }));
+
+  return {
+    data,
+    isLoading,
+    isError,
+  };
+};
+
+export default useGetAllFundingDeadlines;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiSem016.url).reply(() => [200, { deadlines: [] }]);
+});

--- a/packages/web/src/features/executive/funding/hooks/useGetAllFundingDeadlines.ts
+++ b/packages/web/src/features/executive/funding/hooks/useGetAllFundingDeadlines.ts
@@ -10,19 +10,21 @@ import { fundingDeadlinesQueryFn } from "../services/useGetFundingDeadlines";
 type ActivityDuration = ApiSem012ResponseOK["activityDurations"][number];
 
 const useGetAllFundingDeadlines = (activityDurations: ActivityDuration[]) => {
+  const reversedActivityDurations = [...activityDurations].reverse();
+
   const queries = useQueries({
-    queries: activityDurations.map(activityDuration => ({
+    queries: reversedActivityDurations.map(activityDuration => ({
       queryKey: [apiSem016.url, activityDuration.id],
       queryFn: () =>
         fundingDeadlinesQueryFn({ activityDId: activityDuration.id }),
-      enabled: activityDurations.length > 0,
+      enabled: reversedActivityDurations.length > 0,
     })),
   });
 
   const isLoading = queries.some(query => query.isLoading);
   const isError = queries.some(query => query.isError);
   const data = queries.map((query, index) => ({
-    activityDuration: activityDurations[index],
+    activityDuration: reversedActivityDurations[index],
     fundingDeadlines: query.data,
   }));
 

--- a/packages/web/src/features/executive/funding/services/useCreateFundingDeadline.ts
+++ b/packages/web/src/features/executive/funding/services/useCreateFundingDeadline.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  apiSem015,
+  ApiSem015RequestBody,
+  ApiSem015ResponseCreated,
+} from "@clubs/interface/api/semester/apiSem015";
+import { apiSem016 } from "@clubs/interface/api/semester/apiSem016";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useCreateFundingDeadline = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiSem015ResponseCreated, Error, ApiSem015RequestBody>({
+    mutationFn: async (body): Promise<ApiSem015ResponseCreated> => {
+      const { data } = await axiosClientWithAuth.post(apiSem015.url, body);
+
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [apiSem016.url] });
+    },
+  });
+};
+
+export default useCreateFundingDeadline;
+
+defineAxiosMock(mock => {
+  mock.onPost(apiSem015.url).reply(() => [201, {}]);
+});

--- a/packages/web/src/features/executive/funding/services/useDeleteFundingDeadline.ts
+++ b/packages/web/src/features/executive/funding/services/useDeleteFundingDeadline.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { apiSem016 } from "@clubs/interface/api/semester/apiSem016";
+import {
+  apiSem017,
+  ApiSem017RequestParam,
+  ApiSem017ResponseOk,
+} from "@clubs/interface/api/semester/apiSem017";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+const useDeleteFundingDeadline = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ApiSem017ResponseOk, Error, ApiSem017RequestParam>({
+    mutationFn: async (params): Promise<ApiSem017ResponseOk> => {
+      const { data } = await axiosClientWithAuth.delete(
+        apiSem017.url(params.fundingDeadlineId),
+      );
+
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [apiSem016.url] });
+    },
+  });
+};
+
+export default useDeleteFundingDeadline;
+
+defineAxiosMock(mock => {
+  mock.onDelete(apiSem017.url(1)).reply(() => [200, {}]);
+});

--- a/packages/web/src/features/executive/funding/services/useGetFundingDeadlines.ts
+++ b/packages/web/src/features/executive/funding/services/useGetFundingDeadlines.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  apiSem016,
+  ApiSem016RequestQuery,
+  ApiSem016ResponseOk,
+} from "@clubs/interface/api/semester/apiSem016";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+export const fundingDeadlinesQueryFn = async (
+  query: ApiSem016RequestQuery,
+): Promise<ApiSem016ResponseOk> => {
+  try {
+    const { data } = await axiosClientWithAuth.get(apiSem016.url, {
+      params: query,
+    });
+
+    return data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+const useGetFundingDeadlines = (query: ApiSem016RequestQuery = {}) =>
+  useQuery<ApiSem016ResponseOk, Error>({
+    queryKey: [apiSem016.url, query.activityDId],
+    queryFn: () => fundingDeadlinesQueryFn(query),
+  });
+
+export default useGetFundingDeadlines;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiSem016.url).reply(() => [200, { deadlines: [] }]);
+});

--- a/packages/web/src/features/executive/services/useGetActivityDurations.ts
+++ b/packages/web/src/features/executive/services/useGetActivityDurations.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  apiSem012,
+  ApiSem012RequestQuery,
+  ApiSem012ResponseOK,
+} from "@clubs/interface/api/semester/apiSem012";
+
+import {
+  axiosClientWithAuth,
+  defineAxiosMock,
+} from "@sparcs-clubs/web/lib/axios";
+
+export const activityDurationsQueryFn = async (
+  query: ApiSem012RequestQuery,
+): Promise<ApiSem012ResponseOK> => {
+  try {
+    const { data } = await axiosClientWithAuth.get(apiSem012.url(), {
+      params: query,
+    });
+
+    return data;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+const useGetActivityDurations = (query: ApiSem012RequestQuery = {}) =>
+  useQuery<ApiSem012ResponseOK, Error>({
+    queryKey: [apiSem012.url(), query.semesterId],
+    queryFn: () => activityDurationsQueryFn(query),
+  });
+
+export default useGetActivityDurations;
+
+defineAxiosMock(mock => {
+  mock.onGet(apiSem012.url()).reply(() => [200, { activityDurations: [] }]);
+});


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 지원금 기간 관리하는 기능 집행부원 대시보드에 추가했습니다.
- 지원금은 활동기간에 따라 입력해야 해서 기존의 기간 관리 ui를 쓰기엔 무리가 있어 보여 새로 수정했습니다.
- 페이지를 만드는 걸로 수정했고 activityDuration 까지 테이블로 넣으려다 다대다 관계라 보기 불편할 것 같아 section으로 분리했습니다.
- 집행부원 대시보드에 지원금 기간 관리하기 바로가기 버튼 추가하는 김에 다른 항목도 추가했는데 다른 좋은 방안이 있다면 알려주세요

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: https://clubs.stage.sparcs.org/api/docs/#/semester/get_executive_semesters_funding_deadlines
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 집행부원 대시보드 수정함

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 집행부원 대시보드: http://localhost:3000/executive
<img width="1172" height="413" alt="image" src="https://github.com/user-attachments/assets/8b056ba8-3fec-4272-a277-97b2d409f1d8" />

2. 지원금 기간 관리 페이지: http://localhost:3000/executive/funding/deadline
<img width="1507" height="908" alt="image" src="https://github.com/user-attachments/assets/c7577967-bbc6-4fbc-a347-7079a4b113e2" />

3. 지원금 기간 추가 모달
<img width="629" height="556" alt="image" src="https://github.com/user-attachments/assets/dc0677a2-e610-4f75-8274-ab7fa665e8ea" />



