### PR TITLE
[TU-237] 신규 동아리등록 무한 리렌더링 버그 수정

### DIFF
--- a/packages/web/src/features/register-club/components/activity-report/ActivityReportFrame.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/ActivityReportFrame.tsx
@@ -1,5 +1,5 @@
 import { overlay } from "overlay-kit";
-import React from "react";
+import React, { useCallback } from "react";
 import styled from "styled-components";
 
 import AsyncBoundary from "@sparcs-clubs/web/common/components/AsyncBoundary";
@@ -44,7 +44,7 @@ const ActivityReportFrame: React.FC<ActivityReportFrameProps> = ({
     clubId,
   });
 
-  const openCreateActivityReportModal = () => {
+  const openCreateActivityReportModal = useCallback(() => {
     overlay.open(({ isOpen, close }) => (
       <CreateActivityReportModal
         clubId={clubId}
@@ -52,7 +52,7 @@ const ActivityReportFrame: React.FC<ActivityReportFrameProps> = ({
         close={close}
       />
     ));
-  };
+  }, [clubId]);
 
   return (
     <FlexWrapper direction="column" gap={40}>

--- a/packages/web/src/features/register-club/components/activity-report/ActivityReportList.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/ActivityReportList.tsx
@@ -4,7 +4,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { overlay } from "overlay-kit";
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 
 import { ApiAct011ResponseOk } from "@clubs/interface/api/activity/endpoint/apiAct011";
@@ -82,33 +82,42 @@ const ActivityReportList: React.FC<ActivityReportListProps> = ({
   refetch = () => {},
   clubId,
 }) => {
+  const processedData = useMemo(
+    () =>
+      data.map(item => ({
+        ...item,
+        durations: item.durations.map(duration => ({
+          startTerm: duration.startTerm!,
+          endTerm: duration.endTerm!,
+        })),
+      })),
+    [data],
+  );
+
   const table = useReactTable({
     columns,
-    data: data.map(item => ({
-      ...item,
-      durations: item.durations.map(duration => ({
-        startTerm: duration.startTerm!,
-        endTerm: duration.endTerm!,
-      })),
-    })),
+    data: processedData,
     getCoreRowModel: getCoreRowModel(),
     enableSorting: false,
   });
 
-  const openPastActivityReportModal = (activityId: number) => {
-    overlay.open(({ isOpen, close }) => (
-      <PastActivityReportModal
-        profile={profile}
-        activityId={activityId}
-        isOpen={isOpen}
-        close={() => {
-          close();
-          refetch();
-        }}
-        clubId={clubId}
-      />
-    ));
-  };
+  const openPastActivityReportModal = useCallback(
+    (activityId: number) => {
+      overlay.open(({ isOpen, close }) => (
+        <PastActivityReportModal
+          profile={profile}
+          activityId={activityId}
+          isOpen={isOpen}
+          close={() => {
+            close();
+            refetch();
+          }}
+          clubId={clubId}
+        />
+      ));
+    },
+    [profile, clubId],
+  );
 
   return (
     <TableOuter>

--- a/packages/web/src/features/register-club/components/activity-report/_atomic/SelectActivityTerm.tsx
+++ b/packages/web/src/features/register-club/components/activity-report/_atomic/SelectActivityTerm.tsx
@@ -75,7 +75,7 @@ const SelectActivityTerm: React.FC<SelectActivityTermProps> = ({
   };
 
   return (
-    <FlexWrapper direction="column" gap={4}>
+    <FlexWrapper direction="column" gap={4} style={{ width: "100%" }}>
       <Typography fw="MEDIUM" fs={16} lh={20}>
         활동 기간
       </Typography>

--- a/packages/web/src/features/register-club/services/useGetActivityReportsForPromotional.tsx
+++ b/packages/web/src/features/register-club/services/useGetActivityReportsForPromotional.tsx
@@ -12,7 +12,7 @@ export const useGetActivityReportsForPromotional = (
   query: ApiAct011RequestQuery,
 ) =>
   useQuery<ISuccessResponseType, Error>({
-    queryKey: [apiAct011.url()],
+    queryKey: [apiAct011.url(), query.clubId],
     queryFn: async (): Promise<ISuccessResponseType> => {
       const { data } = await axiosClientWithAuth.get(apiAct011.url(), {
         params: query,


### PR DESCRIPTION
# 📌 요약 \*
<!-- 닫는 이슈 번호 및 PR 내용에 대한 간단한 요약 표기. -->

It closes #issue_number

- 신규 동아리 등록의 활보 테이블에서 무한렌더링이 발생하고 있었음
- 아마 테이블 만들 때 data 할당하는 곳에 아래의 데이터 가공 로직도 들어가면서 렌더링이 계속 된게 아닌가 싶음.. 저걸 밖으로 꺼내서 메모이제션 하니까 된듯..? 그 외에 함수들 usecallback 빠진 곳도 추가함
`data: data.map(item => ({
      ...item,
      durations: item.durations.map(duration => ({
        startTerm: duration.startTerm!,
        endTerm: duration.endTerm!,
      })),
    })),`
- 그리고 해당 api 쿼리 키에 clubId가 빠져있길래 그것도 추가함
- 활보 수정 모달 ui 레이아웃이 조금 이상하길래 수정했습니다
- 
<img width="858" height="242" alt="image" src="https://github.com/user-attachments/assets/0f6eda7c-f798-4995-a426-4c602efdcb6f" />

## ⭐문서 링크⭐
<!-- 코드 작성 시 참고한 api시트, figma 링크 첨부 -->
<!-- (백엔드) api 시트: 시트에 변경사항이 발생한 경우 , figma: 리뷰에 도움 될만한 화면(필수아님)-->
1. API sheet: 
2. Figma: 


## 디펜던시 있는 변경사항(혹은 리뷰어가 알아야 할 참고사항)
<!-- 이슈에 관련된 변경사항 외에 주의 깊게 봐야 할 변경사항(예: /common 쪽 코드 변경) -->
- 없음

## 이후 작업해야 할 todo list
<!-- pr이 머지된 후 후속 작업, 혹은 draft pr의 경우 남아있는 todo  -->
- 없음


<!-- 리뷰 요청 시 언제까지 리뷰 해줬으면 좋겠다를 적어주세요  -->
<!-- 급한 경우는 꼭 적어주세요! 안 급하면 생략해도 됨  -->
# 🔴 리뷰 Due Date: x월 x일 (x요일) 


# 📸 스크린샷 
<!-- PR 변경 사항에 대한 스크린샷이나 .gif 파일 -->
프론트의 경우 리뷰가 필요한 화면 URL 목록: 

1. 동아리 상세조회 페이지: http://localhost:3000/clubs/1
